### PR TITLE
Be more permissive W.R.T. client_metadata retrieval

### DIFF
--- a/src/core/authorization_request/parameters.rs
+++ b/src/core/authorization_request/parameters.rs
@@ -163,11 +163,10 @@ impl ClientMetadata {
             ))?
                 .try_into()
                 .context("failed to parse client metadata from JSON");
-        } else {
-            // bail!("the client metadata was not passed by reference or value")
-            println!("[WARNING] the client metadata was not passed by reference or value");
-            return Ok(ClientMetadata(UntypedObject::default()))
         }
+
+        tracing::warn!("the client metadata was not passed by reference or value");
+        Ok(ClientMetadata(UntypedObject::default()))
     }
 }
 

--- a/src/core/authorization_request/parameters.rs
+++ b/src/core/authorization_request/parameters.rs
@@ -163,9 +163,11 @@ impl ClientMetadata {
             ))?
                 .try_into()
                 .context("failed to parse client metadata from JSON");
+        } else {
+            // bail!("the client metadata was not passed by reference or value")
+            println!("[WARNING] the client metadata was not passed by reference or value");
+            return Ok(ClientMetadata(UntypedObject::default()))
         }
-
-        bail!("the client metadata was not passed by reference or value")
     }
 }
 

--- a/src/core/authorization_request/verification/mod.rs
+++ b/src/core/authorization_request/verification/mod.rs
@@ -60,7 +60,9 @@ pub trait RequestVerifier {
         decoded_request: &AuthorizationRequestObject,
         request_jwt: String,
     ) -> Result<(), Error> {
-        bail!("'redirect_uri' client verification not implemented")
+        println!("[WARNING] 'redirect_uri' client verification not implemented");
+        // bail!("'redirect_uri' client verification not implemented")
+        Ok(())
     }
 
     /// Performs verification on Authorization Request Objects when `client_id_scheme` is `verifier_attestation`.

--- a/src/core/authorization_request/verification/mod.rs
+++ b/src/core/authorization_request/verification/mod.rs
@@ -60,9 +60,7 @@ pub trait RequestVerifier {
         decoded_request: &AuthorizationRequestObject,
         request_jwt: String,
     ) -> Result<(), Error> {
-        println!("[WARNING] 'redirect_uri' client verification not implemented");
-        // bail!("'redirect_uri' client verification not implemented")
-        Ok(())
+        bail!("'redirect_uri' client verification not implemented")
     }
 
     /// Performs verification on Authorization Request Objects when `client_id_scheme` is `verifier_attestation`.


### PR DESCRIPTION
Just log a warning if client_metadata was not supplied, and return an empty metadata object.