### PR TITLE
Add info field to Outcome::Success

### DIFF
--- a/src/verifier/session.rs
+++ b/src/verifier/session.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 
 use anyhow::{bail, Error, Ok, Result};
 use async_trait::async_trait;
+use serde_json::Value as Json;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -38,7 +39,7 @@ pub enum Outcome {
     /// The authorization response did not pass verification.
     Failure { reason: String },
     /// The authorization response is verified.
-    Success,
+    Success { info: Json },
 }
 
 /// Storage interface for session information.
@@ -111,7 +112,7 @@ impl Outcome {
         match self {
             Outcome::Error { .. } => 0,
             Outcome::Failure { .. } => 1,
-            Outcome::Success => 2,
+            Outcome::Success { .. } => 2,
         }
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -92,5 +92,8 @@ async fn w3c_vc_did_client_direct_post() {
     assert_eq!(None, redirect);
 
     let status = verifier.poll_status(id).await.unwrap();
-    assert_eq!(Status::Complete(Outcome::Success), status);
+    match status {
+        Status::Complete(Outcome::Success { .. }) => (),
+        _ => panic!("unexpected status: {status:?}"),
+    }
 }

--- a/tests/jwt_vc.rs
+++ b/tests/jwt_vc.rs
@@ -152,7 +152,13 @@ impl AsyncHttpClient for MockHttpClient {
                 id.parse().context("failed to parse id")?,
                 AuthorizationResponse::from_x_www_form_urlencoded(body)
                     .context("failed to parse authorization response request")?,
-                |_, _| Box::pin(async { Outcome::Success }),
+                |_, _| {
+                    Box::pin(async {
+                        Outcome::Success {
+                            info: serde_json::Value::Null,
+                        }
+                    })
+                },
             )
             .await?;
 


### PR DESCRIPTION
This streamlines the implementation, allowing the backend to pass information to the frontend through the receipt of the status.