### PR TITLE
use ssi 0.8.1 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,7 @@ reqwest = { version = "0.12.5", features = ["rustls-tls"] }
 serde = "1.0.188"
 serde_json = "1.0.107"
 serde_urlencoded = "0.7.1"
-ssi-claims = "0.1.0"
-ssi-dids = "0.2.0"
-ssi-jwk = { version = "0.2.1", features = ["secp256r1"] }
-ssi-verification-methods = "0.1.1"
+ssi = { version = "0.8.1", features = ["secp256r1"] }
 tokio = "1.32.0"
 tracing = "0.1.37"
 url = { version = "2.4.1", features = ["serde"] }

--- a/src/core/authorization_request/verification/did.rs
+++ b/src/core/authorization_request/verification/did.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, Context, Result};
 use base64::prelude::*;
 use serde_json::{Map, Value as Json};
 
-use ssi_jwk::JWKResolver;
+use ssi::jwk::JWKResolver;
 
 /// Default implementation of request validation for `client_id_scheme` `did`.
 pub async fn verify_with_resolver(
@@ -17,7 +17,7 @@ pub async fn verify_with_resolver(
     trusted_dids: Option<&[String]>,
     resolver: impl JWKResolver,
 ) -> Result<()> {
-    let (headers_b64, _, _) = ssi_claims::jws::split_jws(&request_jwt)?;
+    let (headers_b64, _, _) = ssi::claims::jws::split_jws(&request_jwt)?;
 
     let headers_json_bytes = BASE64_URL_SAFE_NO_PAD
         .decode(headers_b64)
@@ -70,7 +70,7 @@ pub async fn verify_with_resolver(
         .await
         .context("unable to resolve key from verification method")?;
 
-    let _: Json = ssi_claims::jwt::decode_verify(&request_jwt, &jwk)
+    let _: Json = ssi::claims::jwt::decode_verify(&request_jwt, &jwk)
         .context("request signature could not be verified")?;
 
     Ok(())

--- a/src/core/authorization_request/verification/mod.rs
+++ b/src/core/authorization_request/verification/mod.rs
@@ -106,7 +106,7 @@ pub(crate) async fn verify_request<W: Wallet + ?Sized>(
     jwt: String,
 ) -> Result<AuthorizationRequestObject> {
     let request: AuthorizationRequestObject =
-        ssi_claims::jwt::decode_unverified::<UntypedObject>(&jwt)
+        ssi::claims::jwt::decode_unverified::<UntypedObject>(&jwt)
             .context("unable to decode Authorization Request Object JWT")?
             .try_into()?;
 

--- a/src/core/authorization_request/verification/x509_san.rs
+++ b/src/core/authorization_request/verification/x509_san.rs
@@ -28,7 +28,7 @@ pub fn validate<V: Verifier>(
     trusted_roots: Option<&[Certificate]>,
 ) -> Result<()> {
     let client_id = request_object.client_id().0.as_str();
-    let (headers_b64, body_b64, sig_b64) = ssi_claims::jws::split_jws(&request_jwt)?;
+    let (headers_b64, body_b64, sig_b64) = ssi::claims::jws::split_jws(&request_jwt)?;
 
     let headers_json_bytes = BASE64_URL_SAFE_NO_PAD
         .decode(headers_b64)

--- a/src/core/input_descriptor.rs
+++ b/src/core/input_descriptor.rs
@@ -4,8 +4,8 @@ use crate::utils::NonEmptyVec;
 use anyhow::{bail, Context, Result};
 use jsonschema::{JSONSchema, ValidationError};
 use serde::{Deserialize, Serialize};
-use ssi_claims::jwt::VerifiablePresentation;
-use ssi_dids::ssi_json_ld::syntax::from_value;
+use ssi::claims::jwt::VerifiablePresentation;
+use ssi::dids::ssi_json_ld::syntax::from_value;
 
 /// A GroupId represents a unique identifier for a group of Input Descriptors.
 ///

--- a/src/core/metadata/mod.rs
+++ b/src/core/metadata/mod.rs
@@ -5,7 +5,7 @@ use std::ops::{Deref, DerefMut};
 use anyhow::{Error, Result};
 use parameters::wallet::{RequestObjectSigningAlgValuesSupported, ResponseTypesSupported};
 use serde::{Deserialize, Serialize};
-use ssi_jwk::Algorithm;
+use ssi::jwk::Algorithm;
 
 use self::parameters::wallet::{AuthorizationEndpoint, VpFormatsSupported};
 

--- a/src/core/presentation_definition.rs
+++ b/src/core/presentation_definition.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
-use ssi_claims::jwt::VerifiablePresentation;
+use ssi::claims::jwt::VerifiablePresentation;
 
 /// A presentation definition is a JSON object that describes the information a [Verifier](https://identity.foundation/presentation-exchange/spec/v2.0.0/#term:verifier) requires of a [Holder](https://identity.foundation/presentation-exchange/spec/v2.0.0/#term:holder).
 ///

--- a/src/holder/verifiable_presentation_builder.rs
+++ b/src/holder/verifiable_presentation_builder.rs
@@ -1,10 +1,10 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use ssi_claims::jwt::{VerifiableCredential, VerifiablePresentation};
-use ssi_claims::vc::v2::syntax::VERIFIABLE_PRESENTATION_TYPE;
-use ssi_dids::ssi_json_ld::CREDENTIALS_V1_CONTEXT;
-use ssi_dids::{
+use ssi::claims::jwt::{VerifiableCredential, VerifiablePresentation};
+use ssi::claims::vc::v2::syntax::VERIFIABLE_PRESENTATION_TYPE;
+use ssi::dids::ssi_json_ld::CREDENTIALS_V1_CONTEXT;
+use ssi::dids::{
     ssi_json_ld::syntax::{Object, Value},
     DIDURLBuf,
 };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use serde::Deserialize;
 use serde_json::json;
 use serde_json::Value;
-use ssi_claims::jwt::VerifiablePresentation;
+use ssi::claims::jwt::VerifiablePresentation;
 
 #[test]
 fn request_example() {

--- a/src/verifier/client.rs
+++ b/src/verifier/client.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context as _, Result};
 use async_trait::async_trait;
 use base64::prelude::*;
 use serde_json::{json, Value as Json};
-use ssi_jwk::JWKResolver;
+use ssi::jwk::JWKResolver;
 
 use tracing::debug;
 use x509_cert::{

--- a/src/verifier/request_signer.rs
+++ b/src/verifier/request_signer.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use p256::ecdsa::{signature::Signer, Signature, SigningKey};
-use ssi_claims::jws::{JWSSigner, JWSSignerInfo};
-use ssi_jwk::Algorithm;
+use ssi::claims::jws::{JWSSigner, JWSSignerInfo};
+use ssi::jwk::Algorithm;
 
-use ssi_jwk::JWK;
+use ssi::jwk::JWK;
 
 use std::fmt::Debug;
 
@@ -66,7 +66,7 @@ impl RequestSigner for P256Signer {
 }
 
 impl JWSSigner for P256Signer {
-    async fn fetch_info(&self) -> std::result::Result<JWSSignerInfo, ssi_claims::SignatureError> {
+    async fn fetch_info(&self) -> std::result::Result<JWSSignerInfo, ssi::claims::SignatureError> {
         let algorithm = self.jwk.algorithm.unwrap_or(Algorithm::ES256);
 
         let key_id = self.jwk.key_id.clone();
@@ -77,9 +77,9 @@ impl JWSSigner for P256Signer {
     async fn sign_bytes(
         &self,
         signing_bytes: &[u8],
-    ) -> std::result::Result<Vec<u8>, ssi_claims::SignatureError> {
+    ) -> std::result::Result<Vec<u8>, ssi::claims::SignatureError> {
         self.try_sign(signing_bytes)
             .await
-            .map_err(|e| ssi_claims::SignatureError::Other(format!("Failed to sign bytes: {}", e)))
+            .map_err(|e| ssi::claims::SignatureError::Other(format!("Failed to sign bytes: {}", e)))
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -12,7 +12,7 @@ use oid4vp::{
     verifier::session::{Outcome, Status},
     wallet::Wallet,
 };
-use ssi_jwk::Algorithm;
+use ssi::jwk::Algorithm;
 
 mod jwt_vc;
 mod jwt_vp;

--- a/tests/jwt_vc.rs
+++ b/tests/jwt_vc.rs
@@ -21,8 +21,8 @@ use oid4vp::{
     wallet::Wallet,
 };
 use serde_json::json;
-use ssi_dids::{DIDKey, VerificationMethodDIDResolver};
-use ssi_verification_methods::AnyJwkMethod;
+use ssi::dids::{DIDKey, VerificationMethodDIDResolver};
+use ssi::verification_methods::AnyJwkMethod;
 
 pub async fn wallet_verifier() -> (JwtVcWallet, Arc<Verifier>) {
     let verifier_did = "did:key:zDnaeaDj3YpPR4JXos2kCCNPS86hdELeN5PZh97KGkoFzUtGn".to_owned();

--- a/tests/jwt_vp.rs
+++ b/tests/jwt_vp.rs
@@ -6,9 +6,9 @@ use oid4vp::holder::verifiable_presentation_builder::{
     VerifiablePresentationBuilder, VerifiablePresentationBuilderOptions,
 };
 use oid4vp::verifier::request_signer::P256Signer;
-use ssi_claims::jwt;
-use ssi_dids::DIDKey;
-use ssi_jwk::JWK;
+use ssi::claims::jwt;
+use ssi::dids::DIDKey;
+use ssi::jwk::JWK;
 
 pub async fn create_test_verifiable_presentation() -> Result<String> {
     let verifier = JWK::from_str(include_str!("examples/verifier.jwk"))?;
@@ -26,7 +26,7 @@ pub async fn create_test_verifiable_presentation() -> Result<String> {
     // Create a verifiable presentation using the `examples/vc.jwt` file
     // The signer information is the holder's key, also found in the `examples/subject.jwk` file.
     let verifiable_credential: jwt::VerifiableCredential =
-        ssi_claims::jwt::decode_unverified(include_str!("examples/vc.jwt"))?;
+        ssi::claims::jwt::decode_unverified(include_str!("examples/vc.jwt"))?;
 
     let verifiable_presentation =
         VerifiablePresentationBuilder::from_options(VerifiablePresentationBuilderOptions {


### PR DESCRIPTION
This PR bumps the SSI version to 0.8.1, removing `ssi_*` dependencies.