### PR TITLE
add associative method to presentation definition

### DIFF
--- a/src/core/input_descriptor.rs
+++ b/src/core/input_descriptor.rs
@@ -1,7 +1,8 @@
-use std::collections::HashSet;
-
 use super::{credential_format::*, presentation_submission::*};
 use crate::utils::NonEmptyVec;
+
+use std::collections::HashSet;
+use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
 use jsonschema::{JSONSchema, ValidationError};
@@ -235,7 +236,7 @@ impl InputDescriptor {
                 found_elements = true;
 
                 // If a filter is available with a valid schema, handle the field validation.
-                if let Some(Ok(schema_validator)) = validator.as_ref() {
+                if let Some(schema_validator) = validator.as_ref() {
                     let validated_fields = field_elements.iter().find(|element| {
                         match schema_validator.validate(element) {
                             Err(errors) => {
@@ -398,6 +399,75 @@ impl Constraints {
     }
 }
 
+/// This type is non-normative and used to simplify the construction
+/// of constraint field validators at deserialization and construction,
+/// thereby reducing runtime error checking requirements.
+///
+/// Only the inner raw JSON value is serialized and deserialized.
+#[derive(Debug, Clone)]
+pub struct ConstraintsFieldValidator {
+    raw: serde_json::Value,
+    compiled: Arc<JSONSchema>,
+}
+
+impl ConstraintsFieldValidator {
+    pub fn validator(&self) -> &Arc<JSONSchema> {
+        &self.compiled
+    }
+}
+
+impl AsRef<serde_json::Value> for ConstraintsFieldValidator {
+    fn as_ref(&self) -> &serde_json::Value {
+        &self.raw
+    }
+}
+
+impl<'a> TryFrom<&'a serde_json::Value> for ConstraintsFieldValidator {
+    type Error = ValidationError<'a>;
+
+    fn try_from(value: &'a serde_json::Value) -> Result<Self, Self::Error> {
+        let compiled = JSONSchema::compile(value)?;
+        Ok(Self {
+            raw: value.to_owned(),
+            compiled: Arc::new(compiled),
+        })
+    }
+}
+
+// NOTE: implementing PartialEq directly due to JSONSchema not implementing PartialEq.
+impl PartialEq for ConstraintsFieldValidator {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl Eq for ConstraintsFieldValidator {}
+
+impl Serialize for ConstraintsFieldValidator {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.raw.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ConstraintsFieldValidator {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        D::Error: std::error::Error,
+    {
+        let raw = serde_json::Value::deserialize(deserializer)?;
+
+        let compiled = JSONSchema::compile(&raw).map(Arc::new).map_err(|e| {
+            serde::de::Error::custom(format!("Failed to compile JSON schema: {}", e))
+        })?;
+
+        Ok(ConstraintsFieldValidator { raw, compiled })
+    }
+}
+
 /// ConstraintsField objects are used to describe the constraints that a
 /// [Holder](https://identity.foundation/presentation-exchange/spec/v2.0.0/#term:holder)
 /// must satisfy to fulfill an Input Descriptor.
@@ -415,7 +485,7 @@ pub struct ConstraintsField {
     // Optional predicate value
     predicate: Option<Predicate>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    filter: Option<serde_json::Value>,
+    filter: Option<ConstraintsFieldValidator>,
     #[serde(skip_serializing_if = "Option::is_none")]
     optional: Option<bool>,
     #[serde(default)]
@@ -516,9 +586,19 @@ impl ConstraintsField {
     ///
     /// If present its value MUST be a JSON Schema descriptor used to filter against
     /// the values returned from evaluation of the JSONPath string expressions in the path array.
-    pub fn set_filter(mut self, filter: serde_json::Value) -> Self {
-        self.filter = Some(filter);
-        self
+    pub fn set_filter(mut self, filter: &serde_json::Value) -> Result<Self, ValidationError> {
+        self.filter = Some(ConstraintsFieldValidator::try_from(filter)?);
+        Ok(self)
+    }
+
+    /// Return the raw filter of the constraints field.
+    pub fn filter(&self) -> Option<&serde_json::Value> {
+        self.filter.as_ref().map(|f| f.as_ref())
+    }
+
+    /// Return the validator for the constraints field.
+    pub fn validator(&self) -> Option<&Arc<JSONSchema>> {
+        self.filter.as_ref().map(|f| f.validator())
     }
 
     /// Set the predicate of the constraints field.
@@ -542,23 +622,6 @@ impl ConstraintsField {
     /// See: [https://identity.foundation/presentation-exchange/#predicate-feature](https://identity.foundation/presentation-exchange/#predicate-feature)
     pub fn predicate(&self) -> Option<&Predicate> {
         self.predicate.as_ref()
-    }
-
-    /// Return the raw filter of the constraints field.
-    pub fn filter(&self) -> Option<&serde_json::Value> {
-        self.filter.as_ref()
-    }
-
-    /// Return a JSON schema validator using the internal filter.
-    ///
-    /// If no filter is provided on the constraint field, this
-    /// will return None.
-    ///
-    /// # Errors
-    ///
-    /// If the filter is invalid, this will return an error.
-    pub fn validator(&self) -> Option<Result<JSONSchema, ValidationError>> {
-        self.filter.as_ref().map(JSONSchema::compile)
     }
 
     /// Set the optional value of the constraints field.
@@ -697,6 +760,7 @@ impl ConstraintsField {
             // value for the credential type, e.g. `iso.org.18013.5.1.mDL`, etc.
             if let Some(credential) = self.filter.as_ref().and_then(|filter| {
                 filter
+                    .as_ref()
                     .get("const")
                     .and_then(serde_json::Value::as_str)
                     .map(CredentialType::from)
@@ -707,6 +771,7 @@ impl ConstraintsField {
             // The `type` field may be an array with a nested `const` value.
             if let Some(credential) = self.filter.as_ref().and_then(|filter| {
                 filter
+                    .as_ref()
                     .get("contains")
                     .and_then(|value| value.get("const"))
                     .and_then(serde_json::Value::as_str)
@@ -718,6 +783,7 @@ impl ConstraintsField {
             // The `type` field may be an array with a nested `enum` value.
             if let Some(credential) = self.filter.as_ref().and_then(|filter| {
                 filter
+                    .as_ref()
                     .get("contains")
                     .and_then(|value| value.get("enum"))
                     .and_then(serde_json::Value::as_array)
@@ -736,6 +802,7 @@ impl ConstraintsField {
             // that may satisfy the constraints.
             if let Some(credentials) = self.filter.as_ref().and_then(|filter| {
                 filter
+                    .as_ref()
                     .get("pattern")
                     .and_then(serde_json::Value::as_str)
                     .map(|pattern| {

--- a/src/core/metadata/mod.rs
+++ b/src/core/metadata/mod.rs
@@ -60,7 +60,7 @@ impl WalletMetadata {
     ///     },
     ///     "jwt_vc_json": {
     ///       "alg_values_supported": ["ES256"]
-    ///     }
+    ///     },
     ///   },
     ///   "request_object_signing_alg_values_supported": [
     ///     "ES256"

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -35,10 +35,11 @@ async fn w3c_vc_did_client_direct_post() {
                         .add_path("$.vp.verifiableCredential[0].vc.credentialSubject.id".into())
                         .set_name("Verify Identity Key".into())
                         .set_purpose("Check whether your identity key has been verified.".into())
-                        .set_filter(serde_json::json!({
+                        .set_filter(&serde_json::json!({
                             "type": "string",
                             "pattern": "did:key:.*"
                         }))
+                        .expect("Failed to set filter, invalid validation schema.")
                         .set_predicate(Predicate::Required),
                 )
                 .set_limit_disclosure(ConstraintsLimitDisclosure::Required),


### PR DESCRIPTION
This PR moves the `check_presentation_definition` method in `mobile-sdk-rs` to an associative method on `PresentationDefinition`, which is supplied a `serde_json::Value` encoded credential to check the constraint fields against.