### PR TITLE
add serde for vp_token

### DIFF
--- a/src/core/response/parameters.rs
+++ b/src/core/response/parameters.rs
@@ -44,6 +44,7 @@ impl From<IdToken> for Json {
 ///
 /// See: [OpenID.VP#section-6.1-2.2](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-6.1-2.2)
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum VpToken {
     Single(Vec<u8>),
     SingleAsMap(Map<String, Json>),

--- a/src/core/response/parameters.rs
+++ b/src/core/response/parameters.rs
@@ -4,6 +4,7 @@ use crate::core::presentation_submission::PresentationSubmission as Presentation
 
 use anyhow::{bail, Error};
 use base64::prelude::*;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as Json};
 use ssi::{claims::vc, prelude::AnyJsonPresentation};
 
@@ -42,7 +43,7 @@ impl From<IdToken> for Json {
 /// > any additional encoding when a Credential format is already represented as a JSON object or a JSON string.
 ///
 /// See: [OpenID.VP#section-6.1-2.2](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-6.1-2.2)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum VpToken {
     Single(Vec<u8>),
     SingleAsMap(Map<String, Json>),


### PR DESCRIPTION
This adds serde support for `VpToken`.

NOTE: there is also a `serde_json::Value::from::<VpToken>()` and a `try_from` method.