### PR TITLE
Improve `VpToken` type & other type improvements.

### DIFF
--- a/src/core/presentation_definition.rs
+++ b/src/core/presentation_definition.rs
@@ -28,7 +28,7 @@ pub type CredentialTypesRequestedMap = HashMap<String, CredentialTypesRequestedF
 /// in cases where different types of proofs may satisfy an input requirement.
 ///
 /// For more information, see: [https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition)
-#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PresentationDefinition {
     id: String,
     input_descriptors: Vec<InputDescriptor>,
@@ -306,7 +306,7 @@ impl PresentationDefinition {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SubmissionRequirementObject {
     pub name: Option<String>,
     pub purpose: Option<String>,
@@ -314,7 +314,7 @@ pub struct SubmissionRequirementObject {
     pub property_set: Option<Map<String, serde_json::Value>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum SubmissionRequirementBase {
     From {
@@ -329,7 +329,7 @@ pub enum SubmissionRequirementBase {
     },
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(tag = "rule", rename_all = "snake_case")]
 pub enum SubmissionRequirement {
     All(SubmissionRequirementBase),
@@ -429,7 +429,7 @@ impl SubmissionRequirement {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SubmissionRequirementPick {
     #[serde(flatten)]
     pub submission_requirement: SubmissionRequirementBase,

--- a/src/core/presentation_submission.rs
+++ b/src/core/presentation_submission.rs
@@ -1,6 +1,6 @@
-use super::{credential_format::*, input_descriptor::*};
-
+use super::{credential_format::*, input_descriptor::*, object::TypedParameter};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as Json;
 
 /// A DescriptorMapId is a unique identifier for a DescriptorMap.
 pub type DescriptorMapId = String;
@@ -20,6 +20,10 @@ pub struct PresentationSubmission {
     id: uuid::Uuid,
     definition_id: DescriptorMapId,
     descriptor_map: Vec<DescriptorMap>,
+}
+
+impl TypedParameter for PresentationSubmission {
+    const KEY: &'static str = "presentation_submission";
 }
 
 impl PresentationSubmission {
@@ -74,6 +78,23 @@ impl PresentationSubmission {
             .iter()
             .map(|descriptor_map| (descriptor_map.id.clone(), descriptor_map))
             .collect()
+    }
+}
+
+impl TryFrom<Json> for PresentationSubmission {
+    type Error = anyhow::Error;
+
+    fn try_from(raw: Json) -> Result<Self, Self::Error> {
+        serde_json::from_value(raw.clone()).map_err(Into::into)
+    }
+}
+
+impl From<PresentationSubmission> for Json {
+    fn from(value: PresentationSubmission) -> Self {
+        serde_json::to_value(value)
+            // SAFETY: by definition, a presentation submission has a valid
+            //         JSON representation.
+            .unwrap()
     }
 }
 

--- a/src/core/response/mod.rs
+++ b/src/core/response/mod.rs
@@ -1,4 +1,7 @@
-use super::object::{ParsingErrorContext, UntypedObject};
+use super::{
+    object::{ParsingErrorContext, UntypedObject},
+    presentation_submission::PresentationSubmission,
+};
 
 use std::collections::BTreeMap;
 
@@ -7,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use url::Url;
 
-use self::parameters::{PresentationSubmission, VpToken};
+use self::parameters::VpToken;
 
 pub mod parameters;
 

--- a/src/core/response/parameters.rs
+++ b/src/core/response/parameters.rs
@@ -82,6 +82,18 @@ impl<'de> Deserialize<'de> for VpToken {
     }
 }
 
+impl From<VpTokenItem> for VpToken {
+    fn from(value: VpTokenItem) -> Self {
+        Self(vec![value])
+    }
+}
+
+impl From<String> for VpToken {
+    fn from(value: String) -> Self {
+        Self(vec![value.into()])
+    }
+}
+
 impl From<vc::v1::syntax::JsonPresentation> for VpToken {
     fn from(value: vc::v1::syntax::JsonPresentation) -> Self {
         Self(vec![value.into()])
@@ -139,6 +151,12 @@ impl IntoIterator for VpToken {
 pub enum VpTokenItem {
     String(String),
     JsonObject(serde_json::Map<String, serde_json::Value>),
+}
+
+impl From<String> for VpTokenItem {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
 }
 
 impl From<vc::v1::syntax::JsonPresentation> for VpTokenItem {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -134,7 +134,7 @@ async fn w3c_vc_did_client_direct_post() {
 
     let response = AuthorizationResponse::Unencoded(UnencodedAuthorizationResponse(
         Default::default(),
-        vp.try_into().expect("failed to convert vp to vp token"),
+        vp.into(),
         presentation_submission.try_into().unwrap(),
     ));
 


### PR DESCRIPTION
This PR improves the `VpToken` type definition. The previous definition did not quite fit the specification. It represented a somehow "pre-decoded" token, with a recursive definition. In this new definition, the `VpToken` token strictly follow the syntactic definition of the `vp_token` parameter specification.

Note that I didn't define any decoding method for `VpToken`.

## Other changes

- Added some `PartialEq`, `Eq` implementations
- Removed the seemingly useless `core::response::parameters::PresentationSubmission` type definition.