### PR TITLE
Add license on `oid4vp-frontend`

### DIFF
--- a/oid4vp-frontend/Cargo.toml
+++ b/oid4vp-frontend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oid4vp-frontend"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 serde = "1.0"


### PR DESCRIPTION
Quick fix adding a license key to `oid4vp-frontend`.