### PR TITLE
Improve submission validation and input extraction.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ http = "1.1.0"
 # This is currently used in the jwt_vp test to go from a `VeriableCredential` to an `AnyJsonCredential` type.
 # There may be a better way to handle this that doesn't require the `json-syntax` crate directly.
 json-syntax = { version = "0.12.5", features = ["serde_json"] }
-jsonpath_lib = "0.3.0"
+# jsonpath_lib = "0.3.0"
+serde_json_path = "0.6.7"
 jsonschema = "0.18.0"
 openid4vp-frontend = { version = "0.1.0", path = "openid4vp-frontend" }
 p256 = { version = "0.13.2", features = ["jwk"] }
@@ -34,8 +35,10 @@ tokio = "1.32.0"
 tracing = "0.1.37"
 url = { version = "2.4.1", features = ["serde"] }
 x509-cert = "0.2.4"
+thiserror = "1.0.65"
 
 [dev-dependencies]
+serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_path_to_error = "0.1.8"
 tokio = { version = "1.32.0", features = ["macros"] }
 did-method-key = "0.3"

--- a/src/core/metadata/parameters/verifier.rs
+++ b/src/core/metadata/parameters/verifier.rs
@@ -162,7 +162,7 @@ mod test {
 
         assert_eq!(
             mso_doc,
-            &ClaimFormatPayload::Json(serde_json::Value::Object(Default::default()))
+            &ClaimFormatPayload::Other(serde_json::Value::Object(Default::default()))
         )
     }
 

--- a/src/core/metadata/parameters/wallet.rs
+++ b/src/core/metadata/parameters/wallet.rs
@@ -290,7 +290,7 @@ mod test {
         assert_eq!(m.len(), 1);
         assert_eq!(
             m.remove(&ClaimFormatDesignation::MsoMDoc).unwrap(),
-            ClaimFormatPayload::Json(serde_json::Value::Object(Default::default()))
+            ClaimFormatPayload::Other(serde_json::Value::Object(Default::default()))
         );
     }
 

--- a/src/core/presentation_submission.rs
+++ b/src/core/presentation_submission.rs
@@ -86,7 +86,7 @@ impl PresentationSubmission {
             .collect()
     }
 
-    /// Find all the submission inputs in `value` matching the input descriptor
+    /// Find all the submission inputs in `value` matching the input descriptors
     /// specified in the presentation `definition`.
     pub fn find_inputs<T>(
         &self,
@@ -235,7 +235,7 @@ impl DescriptorMap {
         self
     }
 
-    /// Find all the submission inputs in `value` matching the input descriptor
+    /// Find all the submission inputs in `value` matching the input descriptors
     /// specified in the presentation `definition`.
     ///
     /// Inputs are added to the list of decoded `inputs` provided in argument.
@@ -256,7 +256,7 @@ impl DescriptorMap {
         self.find_inputs_with(definition, &input_descriptors, value, decoder, inputs)
     }
 
-    /// Find all the submission inputs in `value` matching the input descriptor
+    /// Find all the submission inputs in `value` matching the input descriptors
     /// specified in the presentation `definition`.
     ///
     /// This is the same as `find_inputs` but takes the presentation

--- a/src/core/presentation_submission.rs
+++ b/src/core/presentation_submission.rs
@@ -1,6 +1,12 @@
-use super::{credential_format::*, input_descriptor::*, object::TypedParameter};
+use std::{borrow::Cow, collections::HashMap};
+
+use super::{
+    credential_format::*, input_descriptor::*, object::TypedParameter,
+    presentation_definition::PresentationDefinition,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
+use serde_json_path::JsonPath;
 
 /// A DescriptorMapId is a unique identifier for a DescriptorMap.
 pub type DescriptorMapId = String;
@@ -79,6 +85,88 @@ impl PresentationSubmission {
             .map(|descriptor_map| (descriptor_map.id.clone(), descriptor_map))
             .collect()
     }
+
+    /// Find all the submission inputs in `value` matching the input descriptor
+    /// specified in the presentation `definition`.
+    pub fn find_inputs<T>(
+        &self,
+        definition: &PresentationDefinition,
+        value: &serde_json::Value,
+        decoder: &impl ClaimsDecoder<T>,
+    ) -> Result<MatchingInputs<T>, SubmissionError> {
+        let mut inputs = Vec::new();
+        for d in &self.descriptor_map {
+            d.find_inputs(definition, value, decoder, &mut inputs)?;
+        }
+
+        let mut by_descriptor: HashMap<&str, Vec<usize>> = HashMap::new();
+        for (i, input) in inputs.iter().enumerate() {
+            by_descriptor
+                .entry(input.descriptor_id)
+                .or_default()
+                .push(i);
+        }
+
+        Ok(MatchingInputs {
+            inputs,
+            by_descriptor,
+        })
+    }
+
+    /// Find all the submission inputs in `value` matching the input descriptor
+    /// specified in the presentation `definition`, and validate them.
+    pub fn find_and_validate_inputs<T>(
+        &self,
+        definition: &PresentationDefinition,
+        value: &serde_json::Value,
+        decoder: &impl ClaimsDecoder<T>,
+    ) -> Result<MatchingInputs<T>, SubmissionError> {
+        let matches = self.find_inputs(definition, value, decoder)?;
+        matches.validate(definition)?;
+        Ok(matches)
+    }
+}
+
+/// Submission inputs matching the presentation definition.
+pub struct MatchingInputs<'a, T> {
+    /// List of inputs.
+    pub inputs: Vec<DecodedInput<'a, T>>,
+
+    /// Inputs grouped by input descriptor id.
+    pub by_descriptor: HashMap<&'a str, Vec<usize>>,
+}
+
+impl<'a, T> MatchingInputs<'a, T> {
+    /// Validate the inputs against the presentation definition requirements.
+    pub fn validate(
+        &self,
+        definition: &PresentationDefinition,
+    ) -> Result<(), SubmissionValidationError> {
+        match definition.submission_requirements() {
+            Some(requirements) => {
+                for r in requirements {
+                    r.validate(definition, self)?
+                }
+            }
+            None => {
+                // By default each input descriptor must have at least one
+                // associated input.
+                for d in definition.input_descriptors() {
+                    if !self
+                        .by_descriptor
+                        .get(d.id.as_str())
+                        .is_some_and(|i| !i.is_empty())
+                    {
+                        return Err(SubmissionValidationError::MissingRequiredInput(
+                            d.id.clone(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl TryFrom<Json> for PresentationSubmission {
@@ -103,10 +191,10 @@ impl From<PresentationSubmission> for Json {
 /// For more information, see: [https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-submission](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-submission)
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DescriptorMap {
-    id: DescriptorMapId,
-    format: ClaimFormatDesignation,
-    path: JsonPath,
-    path_nested: Option<Box<DescriptorMap>>,
+    pub id: DescriptorMapId,
+    pub format: ClaimFormatDesignation,
+    pub path: JsonPath,
+    pub path_nested: Option<Box<DescriptorMap>>,
 }
 
 impl DescriptorMap {
@@ -130,26 +218,6 @@ impl DescriptorMap {
         }
     }
 
-    /// Return the id of the descriptor map.
-    pub fn id(&self) -> &DescriptorMapId {
-        &self.id
-    }
-
-    /// Return the format of the descriptor map.
-    ///
-    /// The value of this property MUST be a string that matches one of the
-    /// [ClaimFormatDesignation]. This denotes the data format of the Claim.
-    ///
-    /// See: [https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-submission](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-submission)
-    pub fn format(&self) -> &ClaimFormatDesignation {
-        &self.format
-    }
-
-    /// Return the path of the descriptor map.
-    pub fn path(&self) -> &JsonPath {
-        &self.path
-    }
-
     /// Set the nested path of the descriptor map.
     ///
     /// The format of a path_nested object mirrors that of a [DescriptorMap] property. The nesting may be any number of levels deep.
@@ -160,10 +228,272 @@ impl DescriptorMap {
     /// See: [https://identity.foundation/presentation-exchange/spec/v2.0.0/#processing-of-submission-entries](https://identity.foundation/presentation-exchange/spec/v2.0.0/#processing-of-submission-entries)
     pub fn set_path_nested(mut self, mut path_nested: DescriptorMap) -> Self {
         // Ensure the nested path has the same id as the parent.
-        path_nested.id.clone_from(self.id());
+        path_nested.id.clone_from(&self.id);
 
         self.path_nested = Some(Box::new(path_nested));
 
         self
     }
+
+    /// Find all the submission inputs in `value` matching the input descriptor
+    /// specified in the presentation `definition`.
+    ///
+    /// Inputs are added to the list of decoded `inputs` provided in argument.
+    /// Returns an array of indices referencing the inputs added into `inputs`
+    /// by this descriptor map directly. Some more inputs may be added
+    /// indirectly from nested descriptor maps. The index of nested inputs will
+    /// be stored in the `nested` field of the parent `DecodedInput`.
+    ///
+    /// See: <https://identity.foundation/presentation-exchange/spec/v2.0.0/#processing-of-submission-entries>
+    pub fn find_inputs<'a, T>(
+        &'a self,
+        definition: &PresentationDefinition,
+        value: &serde_json::Value,
+        decoder: &impl ClaimsDecoder<T>,
+        inputs: &mut Vec<DecodedInput<'a, T>>,
+    ) -> Result<Vec<usize>, SubmissionError> {
+        let input_descriptors = definition.input_descriptors_map();
+        self.find_inputs_with(definition, &input_descriptors, value, decoder, inputs)
+    }
+
+    /// Find all the submission inputs in `value` matching the input descriptor
+    /// specified in the presentation `definition`.
+    ///
+    /// This is the same as `find_inputs` but takes the presentation
+    /// definition's input descriptor map as parameter.
+    ///
+    /// See: <https://identity.foundation/presentation-exchange/spec/v2.0.0/#processing-of-submission-entries>
+    fn find_inputs_with<'a, T>(
+        &'a self,
+        def: &PresentationDefinition,
+        input_descriptors: &HashMap<&str, &InputDescriptor>,
+        value: &serde_json::Value,
+        decoder: &impl ClaimsDecoder<T>,
+        inputs: &mut Vec<DecodedInput<'a, T>>,
+    ) -> Result<Vec<usize>, SubmissionError> {
+        let mut result = Vec::new();
+
+        let input_desc = input_descriptors
+            .get(self.id.as_str())
+            .ok_or_else(|| SubmissionError::UndefinedInputDescriptor(self.id.clone()))?;
+
+        // Find the appropriate format constraints, if any.
+        let format_constraint = match input_desc.format.get(&self.format) {
+            Some(format_constraint) => Some(format_constraint),
+            None => {
+                if input_desc.format.is_empty() {
+                    match def.format().get(&self.format) {
+                        Some(f) => Some(f),
+                        None => {
+                            if def.format().is_empty() {
+                                None
+                            } else {
+                                return Err(SubmissionError::FormatMismatch(self.format.clone()));
+                            }
+                        }
+                    }
+                } else {
+                    return Err(SubmissionError::FormatMismatch(self.format.clone()));
+                }
+            }
+        };
+
+        for encoded_item in self.path.query(value) {
+            let (decoded_item, decoded_json) =
+                decoder.decode(encoded_item, &self.format, format_constraint)?;
+
+            if !input_desc.constraints.is_empty() {
+                let decoded_json = decoded_json
+                    .as_deref()
+                    .ok_or_else(|| SubmissionError::NestingUnsupported(self.format.clone()))?;
+
+                if !input_desc.constraints.matches(decoded_json) {
+                    continue;
+                }
+            }
+
+            let nested = match &self.path_nested {
+                Some(nested_descriptor) => {
+                    let decoded_json = decoded_json
+                        .as_deref()
+                        .ok_or_else(|| SubmissionError::NestingUnsupported(self.format.clone()))?;
+
+                    let nested = nested_descriptor.find_inputs_with(
+                        def,
+                        input_descriptors,
+                        decoded_json,
+                        decoder,
+                        inputs,
+                    )?;
+
+                    if nested.is_empty() {
+                        continue;
+                    }
+
+                    nested
+                }
+                None => Vec::new(),
+            };
+
+            let nested = group_by_input_descriptor(inputs, nested);
+
+            let i = inputs.len();
+            inputs.push(DecodedInput {
+                descriptor_id: &self.id,
+                format: &self.format,
+                value: decoded_item,
+                nested,
+            });
+            result.push(i);
+        }
+
+        Ok(result)
+    }
+}
+
+/// Presentation submission error.
+#[derive(Debug, thiserror::Error)]
+pub enum SubmissionError {
+    /// Claim decoding failed.
+    #[error("claim decoding failed: {0}")]
+    Decoding(#[from] ClaimDecodingError),
+
+    /// Nesting is not supported for a given claim format.
+    #[error("nesting is not supported for claim format {0}")]
+    NestingUnsupported(ClaimFormatDesignation),
+
+    /// Submission contains inputs that are not defined in the presentation
+    /// definition.
+    #[error("undefined input descriptor: {0}")]
+    UndefinedInputDescriptor(String),
+
+    /// Input format does not match the format expected by the presentation
+    /// definition.
+    #[error("format mismatch: unexpected format {0}")]
+    FormatMismatch(ClaimFormatDesignation),
+
+    /// Input validation failed.
+    #[error("presentation submission validation failed: {0}")]
+    Validation(#[from] SubmissionValidationError),
+}
+
+/// Presentation submission inputs validation error.
+#[derive(Debug, thiserror::Error)]
+pub enum SubmissionValidationError {
+    /// Missing an input required by the presentation definition.
+    #[error("missing required input `{0}`")]
+    MissingRequiredInput(String),
+
+    /// Input group selection is too small.
+    #[error("not enough inputs for group `{group}` (expected at least {min}, found {found})")]
+    SelectionTooSmall {
+        group: GroupId,
+        min: usize,
+        found: usize,
+    },
+
+    /// Input group selection is too large.
+    #[error("too many inputs for group `{group}` (expected at most {max}, found {found})")]
+    SelectionTooLarge {
+        group: GroupId,
+        max: usize,
+        found: usize,
+    },
+
+    /// Input group selection is of the wrong size.
+    #[error("invalid number of inputs for group `{group}` (expected {expected}, found {found})")]
+    SelectionSizeMismatch {
+        group: GroupId,
+        expected: usize,
+        found: usize,
+    },
+}
+
+/// OID4VP claims decoder.
+///
+/// When extracting a presentation submission's inputs, inputs must be decoded
+/// in order to be validated and for nested descriptor to be processed.
+/// Since different applications can support different claim formats, this trait
+/// abstracts the decoding capabilities of the application.
+pub trait ClaimsDecoder<T> {
+    /// Decodes a JSON value according to the given format.
+    ///
+    /// Optional format constraints can be provided.
+    ///
+    /// Returns the decoded claim, and a JSON representation of the decoded
+    /// claims (if any). The JSON representation is used for nested descriptor
+    /// map to be processed.
+    fn decode<'a>(
+        &self,
+        value: &'a serde_json::Value,
+        format: &ClaimFormatDesignation,
+        format_constraint: Option<&ClaimFormatPayload>,
+    ) -> Result<(T, Option<Cow<'a, serde_json::Value>>), ClaimDecodingError>;
+}
+
+pub struct NoClaimsDecoder;
+
+impl ClaimsDecoder<()> for NoClaimsDecoder {
+    fn decode<'a>(
+        &self,
+        value: &'a serde_json::Value,
+        _format: &ClaimFormatDesignation,
+        _format_constraint: Option<&ClaimFormatPayload>,
+    ) -> Result<((), Option<Cow<'a, serde_json::Value>>), ClaimDecodingError> {
+        Ok(((), Some(Cow::Borrowed(value))))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClaimDecodingError {
+    #[error("unknown claim format: {0}")]
+    UnknownFormat(ClaimFormatDesignation),
+
+    #[error("invalid claim: {0}")]
+    Invalid(String),
+}
+
+impl ClaimDecodingError {
+    pub fn invalid(e: impl ToString) -> Self {
+        Self::Invalid(e.to_string())
+    }
+}
+
+/// Groups a set of input indexes by input descriptor id.
+fn group_by_input_descriptor<'a, T>(
+    claims: &[DecodedInput<'a, T>],
+    indexes: Vec<usize>,
+) -> HashMap<&'a str, Vec<usize>> {
+    let mut map: HashMap<&'a str, Vec<usize>> = HashMap::new();
+
+    for i in indexes {
+        let d = claims[i].descriptor_id;
+        map.entry(d).or_default().push(i);
+    }
+
+    map
+}
+
+/// Decoded submission input.
+pub struct DecodedInput<'a, T> {
+    /// Input descriptor id.
+    pub descriptor_id: &'a str,
+
+    /// Claim format.
+    pub format: &'a ClaimFormatDesignation,
+
+    /// Decoded value.
+    pub value: T,
+
+    /// Nested inputs.
+    ///
+    /// This maps each descriptor id to a list of indexes referencing inputs
+    /// that are found nested in this input.
+    ///
+    /// For instance, if this input is a Verifiable Presentation, and the
+    /// presentation definition also specifies an input descriptor `credential`
+    /// for a Verifiable Credential, then this map will include an entry
+    /// `("credential", vec![n])` where `n` is the index of the decoded
+    /// Verifiable Credential input.
+    pub nested: HashMap<&'a str, Vec<usize>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ pub(crate) mod tests;
 mod utils;
 pub mod verifier;
 pub mod wallet;
-pub use jsonpath_lib;
+pub use serde_json_path::JsonPath;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,11 +2,11 @@ use anyhow::{bail, Error};
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(try_from = "Vec<T>", into = "Vec<T>")]
-pub struct NonEmptyVec<T: Clone>(Vec<T>);
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(try_from = "Vec<T>")]
+pub struct NonEmptyVec<T>(Vec<T>);
 
-impl<T: Clone> NonEmptyVec<T> {
+impl<T> NonEmptyVec<T> {
     pub fn new(t: T) -> Self {
         Self(vec![t])
     }
@@ -24,7 +24,7 @@ impl<T: Clone> NonEmptyVec<T> {
     }
 }
 
-impl<T: Clone> TryFrom<Vec<T>> for NonEmptyVec<T> {
+impl<T> TryFrom<Vec<T>> for NonEmptyVec<T> {
     type Error = Error;
 
     fn try_from(v: Vec<T>) -> Result<NonEmptyVec<T>, Error> {
@@ -35,22 +35,49 @@ impl<T: Clone> TryFrom<Vec<T>> for NonEmptyVec<T> {
     }
 }
 
-impl<T: Clone> From<NonEmptyVec<T>> for Vec<T> {
+impl<T> From<NonEmptyVec<T>> for Vec<T> {
     fn from(NonEmptyVec(v): NonEmptyVec<T>) -> Vec<T> {
         v
     }
 }
 
-impl<T: Clone> AsRef<[T]> for NonEmptyVec<T> {
+impl<T> AsRef<[T]> for NonEmptyVec<T> {
     fn as_ref(&self) -> &[T] {
         &self.0
     }
 }
 
-impl<T: Clone> Deref for NonEmptyVec<T> {
+impl<T> Deref for NonEmptyVec<T> {
     type Target = [T];
 
     fn deref(&self) -> &[T] {
         &self.0
+    }
+}
+
+impl<'a, T> IntoIterator for &'a NonEmptyVec<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T> IntoIterator for NonEmptyVec<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<T: Serialize> Serialize for NonEmptyVec<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -29,10 +29,18 @@ async fn w3c_vc_did_client_direct_post() {
                 .add_constraint(
                     // Add a constraint fields to check if the credential
                     // conforms to a specific path.
-                    ConstraintsField::new("$.credentialSubject.id".into())
+                    ConstraintsField::new("$.credentialSubject.id".parse().unwrap())
                         // Add alternative path(s) to check multiple potential formats.
-                        .add_path("$.vp.verifiableCredential.vc.credentialSubject.id".into())
-                        .add_path("$.vp.verifiableCredential[0].vc.credentialSubject.id".into())
+                        .add_path(
+                            "$.vp.verifiableCredential.vc.credentialSubject.id"
+                                .parse()
+                                .unwrap(),
+                        )
+                        .add_path(
+                            "$.vp.verifiableCredential[0].vc.credentialSubject.id"
+                                .parse()
+                                .unwrap(),
+                        )
                         .set_name("Verify Identity Key".into())
                         .set_purpose("Check whether your identity key has been verified.".into())
                         .set_filter(&serde_json::json!({
@@ -95,7 +103,7 @@ async fn w3c_vc_did_client_direct_post() {
             // NOTE: the input descriptor constraint field path is relative to the path
             // of the descriptor map matching the input descriptor id.
             DescriptorMap::new(
-                descriptor.id().to_string(),
+                descriptor.id.clone(),
                 // NOTE: Since the input descriptor may support several different
                 // claim format types. This value should not be hardcoded in production
                 // code, but should be selected from available formats in the presentation definition
@@ -106,18 +114,18 @@ async fn w3c_vc_did_client_direct_post() {
                 // Starts at the top level path of the verifiable submission, which contains a `vp` key
                 // for verifiable presentations, which include the verifiable credentials under the `verifiableCredentials`
                 // field.
-                "$".into(),
+                "$".parse().unwrap(),
             )
             .set_path_nested(DescriptorMap::new(
                 // Descriptor map id must be the same as the parent descriptor map id.
-                descriptor.id().to_string(),
+                descriptor.id.clone(),
                 ClaimFormatDesignation::JwtVcJson,
                 // This nested path is relative to the resolved path of the parent descriptor map.
                 // In this case, the parent descriptor map resolved to the `vp` key.
                 // The nested path is relative to the `vp` key.
                 //
                 // See: https://identity.foundation/presentation-exchange/spec/v2.0.0/#processing-of-submission-entries
-                "$.vp.verifiableCredential[0]".into(),
+                "$.vp.verifiableCredential[0]".parse().unwrap(),
             ))
         })
         .collect();


### PR DESCRIPTION
This PR improves the presentation submission validation in two ways:

- Input extraction: currently we are only doing validation. But I also needed to extract the inputs provided in the submission. I added a `PresentationSubmission::find_inputs` function to find and extract the inputs. It returns a `MatchingInputs` structure containing all the inputs that matched the presentation definition.
- Input decoding: currently the presentation submission inputs are not decoded, which is required to correctly handle nested descriptor maps. I've added a `ClaimsDecoder` trait that is given to the `find_inputs` to decode the visited input claims. I provided a "default" implementation `NoClaimsDecoder` that doesn't decode anything (so it behaves exactly like the current implementation).

For the validation part:
- I added a `MatchingInput::validate` to validate the extracted input against the presentation definition requirements.
- I replaced the previous validation function with `PresentationSubmission::find_and_validate_inputs` that just calls `find_inputs` and `validate`.

## Other changes

I've set some fields public and removed some accessors.