### PR TITLE
Feat/add req obj signing alg setter wallet metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ http = "1.1.0"
 # There may be a better way to handle this that doesn't require the `json-syntax` crate directly.
 json-syntax = { version = "0.12.5", features = ["serde_json"] }
 # jsonpath_lib = "0.3.0"
-serde_json_path = "0.6.7"
+serde_json_path = "0.7.1"
 jsonschema = "0.18.0"
 openid4vp-frontend = { version = "0.1.0", path = "openid4vp-frontend" }
 p256 = { version = "0.13.2", features = ["jwk"] }

--- a/src/core/metadata/mod.rs
+++ b/src/core/metadata/mod.rs
@@ -49,6 +49,25 @@ impl WalletMetadata {
         &mut self.2
     }
 
+    /// Add a request object signing algorithm to the list of the request object
+    /// signing algorithms supported.
+    pub fn add_request_object_signing_alg_values_supported(
+        &mut self,
+        alg: Algorithm,
+    ) -> Result<()> {
+        let mut supported = self
+            .0
+            .get_or_default::<RequestObjectSigningAlgValuesSupported>()?;
+
+        // Insert the algorithm.
+        supported.0.push(alg.to_string());
+
+        // Insert the updated request object signing algorithms supported.
+        self.0.insert(supported);
+
+        Ok(())
+    }
+
     /// Add a client ID scheme to the list of the client ID schemes supported.
     ///
     /// This method will construct a `client_id_schemes_supported` proprety in the

--- a/src/core/metadata/parameters/wallet.rs
+++ b/src/core/metadata/parameters/wallet.rs
@@ -113,7 +113,7 @@ impl Default for ClientIdSchemesSupported {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RequestObjectSigningAlgValuesSupported(pub Vec<String>);
 
 impl TypedParameter for RequestObjectSigningAlgValuesSupported {

--- a/src/core/object/mod.rs
+++ b/src/core/object/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use anyhow::{Context, Error, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as Json};
@@ -60,21 +58,6 @@ impl UntypedObject {
                     .map_err(Into::into),
             ),
         }
-    }
-
-    /// Flatten the structure for posting as a form.
-    pub(crate) fn flatten_for_form(self) -> Result<BTreeMap<String, String>> {
-        self.0
-            .into_iter()
-            .map(|(k, v)| {
-                if let Json::String(s) = v {
-                    return Ok((k, s));
-                }
-                serde_json::to_string(&v)
-                    .map(|v| (k, v))
-                    .map_err(Error::from)
-            })
-            .collect()
     }
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -140,11 +140,10 @@ async fn w3c_vc_did_client_direct_post() {
         .await
         .expect("failed to create verifiable presentation");
 
-    let response = AuthorizationResponse::Unencoded(UnencodedAuthorizationResponse(
-        Default::default(),
-        vp.into(),
-        presentation_submission.try_into().unwrap(),
-    ));
+    let response = AuthorizationResponse::Unencoded(UnencodedAuthorizationResponse {
+        vp_token: vp.into(),
+        presentation_submission: presentation_submission.try_into().unwrap(),
+    });
 
     let status = verifier.poll_status(id).await.unwrap();
     assert_eq!(Status::SentRequest, status);


### PR DESCRIPTION
Changes:

- **Cargo.toml:** Updated the serde_json_path dependency from version 0.6.7 to 0.7.1.

- **src/core/metadata/mod.rs:** Added a new method add_request_object_signing_alg_values_supported to the WalletMetadata struct, which allows adding a request object signing algorithm to the list of supported algorithms.

- **src/core/metadata/parameters/wallet.rs:** Modified the RequestObjectSigningAlgValuesSupported struct to derive the Default trait.

- **src/core/object/mod.rs:** Removed the flatten_for_form method from the UntypedObject struct.

- **src/core/response/mod.rs:** Refactored the AuthorizationResponse to use a new JsonEncodedAuthorizationResponse struct for encoding and decoding. Updated the UnencodedAuthorizationResponse struct and added methods for handling VpToken and PresentationSubmission.

- Added implementations for VpToken to handle serialization, deserialization, and conversions from various types like String and JsonPresentation.

- Introduced the JsonEncodedAuthorizationResponse struct to handle the encoding of VpToken and PresentationSubmission.
