### PR TITLE
add data integrity conversion for vp token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ reqwest = { version = "0.12.5", features = ["rustls-tls"] }
 serde = "1.0.188"
 serde_json = "1.0.107"
 serde_urlencoded = "0.7.1"
-ssi = { version = "0.10", features = ["secp256r1"] }
+ssi = { version = "0.10.1", features = ["secp256r1"] }
 tokio = "1.32.0"
 tracing = "0.1.37"
 url = { version = "2.4.1", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ http = "1.1.0"
 # There may be a better way to handle this that doesn't require the `json-syntax` crate directly.
 json-syntax = { version = "0.12.5", features = ["serde_json"] }
 # jsonpath_lib = "0.3.0"
-serde_json_path = "0.6.7"
+serde_json_path = "0.7.1"
 jsonschema = "0.18.0"
 openid4vp-frontend = { version = "0.1.0", path = "openid4vp-frontend" }
 p256 = { version = "0.13.2", features = ["jwk"] }

--- a/src/core/authorization_request/mod.rs
+++ b/src/core/authorization_request/mod.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use anyhow::{anyhow, bail, Context, Error, Result};
+use parameters::ClientMetadata;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
 use url::Url;
@@ -16,6 +17,7 @@ use self::{
 };
 
 use super::{
+    metadata::parameters::verifier::VpFormats,
     object::{ParsingErrorContext, UntypedObject},
     util::{base_request, AsyncHttpClient},
 };
@@ -262,6 +264,21 @@ impl AuthorizationRequestObject {
 
     pub fn nonce(&self) -> &Nonce {
         &self.7
+    }
+
+    /// Return the `client_metadata` field from the authorization request.
+    pub fn client_metadata(&self) -> Result<ClientMetadata> {
+        self.0
+            .get()
+            .ok_or(anyhow!("missing `client_metadata` object"))?
+    }
+
+    /// Return the `VpFormats` from the `client_metadata` field.
+    pub fn vp_formats(&self) -> Result<VpFormats> {
+        self.client_metadata()?
+            .0
+            .get()
+            .ok_or(anyhow!("missing vp_formats"))?
     }
 }
 

--- a/src/core/authorization_request/verification/did.rs
+++ b/src/core/authorization_request/verification/did.rs
@@ -43,7 +43,6 @@ pub async fn verify_with_resolver(
     // This bypass is for unencoded JWT requests, but we will need to change this later
     // so that trust is preserved when receiving unencoded requests
     if alg.contains("none") {
-        // bail!("UNSIGNED JWT")
         return Ok(());
     }
 

--- a/src/core/authorization_request/verification/did.rs
+++ b/src/core/authorization_request/verification/did.rs
@@ -40,6 +40,13 @@ pub async fn verify_with_resolver(
         bail!("request was signed with unsupported algorithm: {alg}")
     }
 
+    // This bypass is for unencoded JWT requests, but we will need to change this later
+    // so that trust is preserved when receiving unencoded requests
+    if alg.contains("none") {
+        // bail!("UNSIGNED JWT")
+        return Ok(());
+    }
+
     let Json::String(kid) = headers
         .remove("kid")
         .context("'kid' was missing from jwt headers")?

--- a/src/core/authorization_request/verification/did.rs
+++ b/src/core/authorization_request/verification/did.rs
@@ -40,6 +40,14 @@ pub async fn verify_with_resolver(
         bail!("request was signed with unsupported algorithm: {alg}")
     }
 
+    // This bypass is for unencoded JWT requests, but we will need to change this later
+    // so that trust is preserved when receiving unencoded requests
+    // NOTE: This requires that `Algorithm::None` is permitted in the wallet metadata
+    // Otherwise, this function will error in the previous assertion.
+    if alg.contains("none") {
+        return Ok(());
+    }
+
     let Json::String(kid) = headers
         .remove("kid")
         .context("'kid' was missing from jwt headers")?

--- a/src/core/authorization_request/verification/did.rs
+++ b/src/core/authorization_request/verification/did.rs
@@ -40,12 +40,6 @@ pub async fn verify_with_resolver(
         bail!("request was signed with unsupported algorithm: {alg}")
     }
 
-    // This bypass is for unencoded JWT requests, but we will need to change this later
-    // so that trust is preserved when receiving unencoded requests
-    if alg.contains("none") {
-        return Ok(());
-    }
-
     let Json::String(kid) = headers
         .remove("kid")
         .context("'kid' was missing from jwt headers")?

--- a/src/core/credential_format/mod.rs
+++ b/src/core/credential_format/mod.rs
@@ -137,6 +137,7 @@ pub enum ClaimFormatPayload {
     /// claim presentation algorithm types supported by a wallet.
     #[serde(rename = "alg_values_supported")]
     AlgValuesSupported(Vec<String>),
+    /// This variant is primarily used for `ldp`, `ldp_vc`, `ldp_vp`, `ac_vc`, and `ac_vp`
     #[serde(rename = "proof_type")]
     ProofType(Vec<String>),
     #[serde(untagged)]

--- a/src/core/input_descriptor.rs
+++ b/src/core/input_descriptor.rs
@@ -209,6 +209,11 @@ impl Constraints {
         self.fields.as_ref()
     }
 
+    /// Returns the fields of the constraints object as a mutable reference.
+    pub fn fields_mut(&mut self) -> &mut Vec<ConstraintsField> {
+        self.fields.as_mut()
+    }
+
     /// Set the limit disclosure value.
     ///
     /// For all [Claims](https://identity.foundation/presentation-exchange/spec/v2.0.0/#term:claims) submitted in relation to [InputDescriptor] Objects that include a `constraints`

--- a/src/core/metadata/mod.rs
+++ b/src/core/metadata/mod.rs
@@ -49,6 +49,25 @@ impl WalletMetadata {
         &mut self.2
     }
 
+    /// Add a request object signing algorithm to the list of the request object
+    /// signing algorithms supported.
+    pub fn add_request_object_signing_alg_values_supported(
+        &mut self,
+        alg: Algorithm,
+    ) -> Result<()> {
+        let mut supported = self
+            .0
+            .get_or_default::<RequestObjectSigningAlgValuesSupported>()?;
+
+        // Insert the algorithm.
+        supported.0.push(alg.to_string());
+
+        // Insert the updated request object signing algorithms supported.
+        self.0.insert(supported);
+
+        Ok(())
+    }
+
     /// Add a client ID scheme to the list of the client ID schemes supported.
     ///
     /// This method will construct a `client_id_schemes_supported` proprety in the

--- a/src/core/metadata/parameters/verifier.rs
+++ b/src/core/metadata/parameters/verifier.rs
@@ -10,25 +10,28 @@ use serde_json::{Map, Value as Json};
 pub struct VpFormats(pub ClaimFormatMap);
 
 impl VpFormats {
-    /// Returns a boolean to denote whether the format and cryptosuite provided
-    /// are supported in the VP formats.
+    /// Returns a boolean to denote whether a particular pair of format and security method
+    /// are supported in the VP formats. A security method could be a JOSE algorithm, a COSE
+    /// algorithm, a Cryptosuite, etc.
     ///
-    /// NOTE: This method is interested in the cryptosuite of the claim format
+    /// NOTE: This method is interested in the security method of the claim format
     /// payload and not the claim format designation.
     ///
-    /// For example, the cryptosuite would need to match one of the `alg`
+    /// For example, the security method would need to match one of the `alg`
     /// values in the claim format payload.
-    pub fn supports_cryptosuite(
+    pub fn supports_security_method(
         &self,
         format: &ClaimFormatDesignation,
-        cryptosuite: &String,
+        security_method: &String,
     ) -> bool {
         match self.0.get(format) {
             Some(ClaimFormatPayload::Alg(alg_values))
             | Some(ClaimFormatPayload::AlgValuesSupported(alg_values)) => {
-                alg_values.contains(cryptosuite)
+                alg_values.contains(security_method)
             }
-            Some(ClaimFormatPayload::ProofType(proof_types)) => proof_types.contains(cryptosuite),
+            Some(ClaimFormatPayload::ProofType(proof_types)) => {
+                proof_types.contains(security_method)
+            }
             _ => false,
         }
     }

--- a/src/core/metadata/parameters/wallet.rs
+++ b/src/core/metadata/parameters/wallet.rs
@@ -113,7 +113,7 @@ impl Default for ClientIdSchemesSupported {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RequestObjectSigningAlgValuesSupported(pub Vec<String>);
 
 impl TypedParameter for RequestObjectSigningAlgValuesSupported {

--- a/src/core/object/mod.rs
+++ b/src/core/object/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use anyhow::{Context, Error, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as Json};
@@ -60,21 +58,6 @@ impl UntypedObject {
                     .map_err(Into::into),
             ),
         }
-    }
-
-    /// Flatten the structure for posting as a form.
-    pub(crate) fn flatten_for_form(self) -> Result<BTreeMap<String, String>> {
-        self.0
-            .into_iter()
-            .map(|(k, v)| {
-                if let Json::String(s) = v {
-                    return Ok((k, s));
-                }
-                serde_json::to_string(&v)
-                    .map(|v| (k, v))
-                    .map_err(Error::from)
-            })
-            .collect()
     }
 }
 

--- a/src/core/response/parameters.rs
+++ b/src/core/response/parameters.rs
@@ -8,7 +8,7 @@ use ssi::{
     claims::vc::{self, v2::SpecializedJsonCredential},
     json_ld::syntax::Object,
     one_or_many::OneOrManyRef,
-    prelude::{AnyDataIntegrity, AnyJsonPresentation},
+    prelude::{AnyDataIntegrity, AnyJsonPresentation, AnySuite, DataIntegrity},
     OneOrMany,
 };
 
@@ -234,6 +234,20 @@ impl From<AnyJsonPresentation> for VpTokenItem {
             .unwrap()
         else {
             // SAFETY: by definition a VCDM presentation is a JSON object.
+            unreachable!()
+        };
+
+        Self::JsonObject(obj)
+    }
+}
+
+impl From<DataIntegrity<AnyJsonPresentation, AnySuite>> for VpTokenItem {
+    fn from(value: DataIntegrity<AnyJsonPresentation, AnySuite>) -> Self {
+        let serde_json::Value::Object(obj) = serde_json::to_value(value)
+            // SAFETY: by definition a VCDM2.0 presentation is a JSON object.
+            .unwrap()
+        else {
+            // SAFETY: by definition a VCDM2.0 presentation is a JSON object.
             unreachable!()
         };
 

--- a/src/core/response/parameters.rs
+++ b/src/core/response/parameters.rs
@@ -8,7 +8,7 @@ use ssi::{
     claims::vc::{self, v2::SpecializedJsonCredential},
     json_ld::syntax::Object,
     one_or_many::OneOrManyRef,
-    prelude::AnyJsonPresentation,
+    prelude::{AnyDataIntegrity, AnyJsonPresentation},
     OneOrMany,
 };
 
@@ -112,6 +112,12 @@ impl From<vc::v2::syntax::JsonPresentation> for VpToken {
     }
 }
 
+impl From<vc::v2::syntax::JsonPresentation<SpecializedJsonCredential<Object>>> for VpToken {
+    fn from(value: vc::v2::syntax::JsonPresentation<SpecializedJsonCredential<Object>>) -> Self {
+        Self(vec![value.into()])
+    }
+}
+
 impl From<AnyJsonPresentation> for VpToken {
     fn from(value: AnyJsonPresentation) -> Self {
         Self(vec![value.into()])
@@ -162,6 +168,20 @@ pub enum VpTokenItem {
 impl From<String> for VpTokenItem {
     fn from(value: String) -> Self {
         Self::String(value)
+    }
+}
+
+impl From<AnyDataIntegrity> for VpTokenItem {
+    fn from(value: AnyDataIntegrity) -> Self {
+        let serde_json::Value::Object(obj) = serde_json::to_value(&value)
+            // SAFETY: by definition a Data Integrity Object is a Json LD Node and is a JSON object.
+            .unwrap()
+        else {
+            // SAFETY: by definition a Data Integrity Object is a Json LD Node and is a JSON object.
+            unreachable!()
+        };
+
+        Self::JsonObject(obj)
     }
 }
 

--- a/src/core/response/parameters.rs
+++ b/src/core/response/parameters.rs
@@ -4,7 +4,13 @@ use crate::core::object::TypedParameter;
 use anyhow::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
-use ssi::{claims::vc, one_or_many::OneOrManyRef, prelude::AnyJsonPresentation, OneOrMany};
+use ssi::{
+    claims::vc::{self, v2::SpecializedJsonCredential},
+    json_ld::syntax::Object,
+    one_or_many::OneOrManyRef,
+    prelude::AnyJsonPresentation,
+    OneOrMany,
+};
 
 #[derive(Debug, Clone)]
 pub struct IdToken(pub String);
@@ -175,6 +181,20 @@ impl From<vc::v1::syntax::JsonPresentation> for VpTokenItem {
 
 impl From<vc::v2::syntax::JsonPresentation> for VpTokenItem {
     fn from(value: vc::v2::syntax::JsonPresentation) -> Self {
+        let serde_json::Value::Object(obj) = serde_json::to_value(value)
+            // SAFETY: by definition a VCDM2.0 presentation is a JSON object.
+            .unwrap()
+        else {
+            // SAFETY: by definition a VCDM2.0 presentation is a JSON object.
+            unreachable!()
+        };
+
+        Self::JsonObject(obj)
+    }
+}
+
+impl From<vc::v2::syntax::JsonPresentation<SpecializedJsonCredential<Object>>> for VpTokenItem {
+    fn from(value: vc::v2::syntax::JsonPresentation<SpecializedJsonCredential<Object>>) -> Self {
         let serde_json::Value::Object(obj) = serde_json::to_value(value)
             // SAFETY: by definition a VCDM2.0 presentation is a JSON object.
             .unwrap()

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -140,11 +140,10 @@ async fn w3c_vc_did_client_direct_post() {
         .await
         .expect("failed to create verifiable presentation");
 
-    let response = AuthorizationResponse::Unencoded(UnencodedAuthorizationResponse(
-        Default::default(),
-        vp.into(),
-        presentation_submission.try_into().unwrap(),
-    ));
+    let response = AuthorizationResponse::Unencoded(UnencodedAuthorizationResponse {
+        vp_token: vp.into(),
+        presentation_submission: presentation_submission.try_into().unwrap(),
+    });
 
     let status = verifier.poll_status(id).await.unwrap();
     assert_eq!(Status::SentRequest, status);


### PR DESCRIPTION
Additionally adds a check for authorization request vp formats supported to check cryptosuite against
expected response formats.