### PR TITLE
[FIX] Remove extraneous quotations around url encoded vp_token

### DIFF
--- a/src/core/authorization_request/mod.rs
+++ b/src/core/authorization_request/mod.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use anyhow::{anyhow, bail, Context, Error, Result};
-use parameters::ClientMetadata;
+use parameters::{ClientMetadata, State};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
 use url::Url;
@@ -279,6 +279,12 @@ impl AuthorizationRequestObject {
             .0
             .get()
             .ok_or(anyhow!("missing vp_formats"))?
+    }
+
+    /// Return the `state` of the authorization request,
+    /// if it was provided.
+    pub fn state(&self) -> Option<Result<State>> {
+        self.0.get()
     }
 }
 

--- a/src/core/authorization_request/parameters.rs
+++ b/src/core/authorization_request/parameters.rs
@@ -576,7 +576,7 @@ impl From<ResponseType> for Json {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct State(pub String);
 
 impl TypedParameter for State {

--- a/src/core/presentation_submission.rs
+++ b/src/core/presentation_submission.rs
@@ -194,6 +194,7 @@ pub struct DescriptorMap {
     pub id: DescriptorMapId,
     pub format: ClaimFormatDesignation,
     pub path: JsonPath,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub path_nested: Option<Box<DescriptorMap>>,
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -144,6 +144,7 @@ async fn w3c_vc_did_client_direct_post() {
         vp_token: vp.into(),
         presentation_submission: presentation_submission.try_into().unwrap(),
         state: None,
+        should_strip_quotes: false,
     });
 
     let status = verifier.poll_status(id).await.unwrap();

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -143,6 +143,7 @@ async fn w3c_vc_did_client_direct_post() {
     let response = AuthorizationResponse::Unencoded(UnencodedAuthorizationResponse {
         vp_token: vp.into(),
         presentation_submission: presentation_submission.try_into().unwrap(),
+        state: None,
     });
 
     let status = verifier.poll_status(id).await.unwrap();

--- a/tests/jwt_vc.rs
+++ b/tests/jwt_vc.rs
@@ -157,7 +157,7 @@ impl AsyncHttpClient for MockHttpClient {
         self.verifier
             .verify_response(
                 id.parse().context("failed to parse id")?,
-                AuthorizationResponse::from_x_www_form_urlencoded(body)
+                AuthorizationResponse::from_x_www_form_urlencoded(body, false)
                     .context("failed to parse authorization response request")?,
                 |_, _| {
                     Box::pin(async move {


### PR DESCRIPTION
This PR adds a helper method `clean_quoted_string` to strip extra quotations in JSON encoded `vp_token` payload for url encoding.

There might be a better way to serialize the `VpToken` to ensure an extra quotation is not included, open to suggestions.

Drive by changes:

- Adds an optional `state` property to from the authorization request to the authorization response.
- Adds some serde derive macros to help debug.