### PR TITLE
Fix request indirection deserialization

### DIFF
--- a/src/core/authorization_request/mod.rs
+++ b/src/core/authorization_request/mod.rs
@@ -41,12 +41,14 @@ pub struct AuthorizationRequestObject {
 pub struct AuthorizationRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub client_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub client_id_scheme: Option<String>,
     #[serde(flatten)]
     pub request_indirection: RequestIndirection,
 }
 
 /// A RequestObject, passed by value or by reference.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum RequestIndirection {
     #[serde(rename = "request")]
     ByValue(String),
@@ -149,6 +151,7 @@ impl AuthorizationRequest {
     /// let authorization_endpoint: Url = "example://".parse().unwrap();
     /// let authorization_request = AuthorizationRequest {
     ///     client_id: Some("xyz".to_string()),
+    ///     client_id_scheme: None,
     ///     request_indirection: RequestIndirection::ByValue("test".to_string()),
     /// };
     ///
@@ -385,5 +388,178 @@ impl Deref for AuthorizationRequestObject {
 impl DerefMut for AuthorizationRequestObject {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn deserialize_authorization_request_object() {
+        let json = json!({
+          "aud": "https://self-issued.me/v2",
+          "response_type": "vp_token",
+          "presentation_definition": {
+            "id": "b5323a8f-493b-4e5c-a766-4f7ed28424f7",
+            "input_descriptors": [
+              {
+                "id": "org.iso.18013.5.1.mDL",
+                "format": {
+                  "mso_mdoc": {
+                    "alg": [
+                      "ES256"
+                    ]
+                  }
+                },
+                "constraints": {
+                  "fields": [
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['family_name']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['given_name']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['birth_date']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['issue_date']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['expiry_date']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['issuing_country']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['issuing_authority']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['document_number']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['portrait']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['driving_privileges']"
+                      ],
+                      "intent_to_retain": true
+                    },
+                    {
+                      "path": [
+                        "$['org.iso.18013.5.1']['un_distinguishing_sign']"
+                      ],
+                      "intent_to_retain": true
+                    }
+                  ],
+                  "limit_disclosure": "required"
+                }
+              }
+            ]
+          },
+          "client_metadata": {
+            "jwks": {
+              "keys": [
+                {
+                  "kty": "EC",
+                  "crv": "P-256",
+                  "x": "StF0H4foaK2f_ed4aw6FwNALrHz7FkGk5Iz9TtiRjyo",
+                  "y": "OCgRLGrs6lZHp1Rye2xJ3r9aXdMP1DcoeQuNpA0ryn8",
+                  "kid": "f67813a4-7a2a-4c39-b290-c0d03f372400",
+                  "alg": "ECDH-ES",
+                  "use": "enc"
+                }
+              ]
+            },
+            "authorization_encrypted_response_enc": "A256GCM",
+            "authorization_encrypted_response_alg": "ECDH-ES",
+            "vp_formats": {
+              "mso_mdoc": {
+                "alg": [
+                  "ES256",
+                  "ES384",
+                  "ES512",
+                  "EdDSA"
+                ]
+              }
+            },
+            "require_signed_request_object": true
+          },
+          "state": "134ea6fe-cfe9-4243-b349-d00a8edb38e4",
+          "nonce": "mG2Xi1nVIIepJ7fwwj5qjNgNzp7KOYOhJbvAlbKCJYI",
+          "client_id": "labs-online-presentation-sample-app.vii.au01.mattr.global",
+          "client_id_scheme": "x509_san_dns",
+          "response_mode": "direct_post.jwt",
+          "response_uri": "https://labs-online-presentation-sample-app.vii.au01.mattr.global/v2/presentations/sessions/response"
+        });
+        let untyped_object: UntypedObject = serde_json::from_value(json).unwrap();
+        let authorization_request_object: AuthorizationRequestObject =
+            untyped_object.try_into().unwrap();
+        assert_eq!(
+            authorization_request_object.response_mode,
+            ResponseMode::DirectPostJwt
+        );
+    }
+
+    #[test]
+    fn deserialize_authorization_request_object_jwt() {
+        let jwt = "eyJhbGciOiJFUzI1NiIsImtpZCI6IjJlYzI5MDFlLTc2Y2EtNDE2Yy04ODBlLTgzY2U2ODkzYjdkYSIsIng1YyI6WyJNSUlEb2pDQ0EwbWdBd0lCQWdJS1pXSlM1RGVsN3BxTXd6QUtCZ2dxaGtqT1BRUURBakJhTVFzd0NRWURWUVFHRXdKT1dqRkxNRWtHQTFVRUF3eENiR0ZpY3kxdmJteHBibVV0Y0hKbGMyVnVkR0YwYVc5dUxYTmhiWEJzWlMxaGNIQXVkbWxwTG1GMU1ERXViV0YwZEhJdVoyeHZZbUZzSUZabGNtbG1hV1Z5TUI0WERUSTFNRFV4TXpFd016ZzFNMW9YRFRJMU1URXhNVEV3TXpnMU0xb3daekVMTUFrR0ExVUVCaE1DVGxveFdEQldCZ05WQkFNTVQyeGhZbk10YjI1c2FXNWxMWEJ5WlhObGJuUmhkR2x2YmkxellXMXdiR1V0WVhCd0xuWnBhUzVoZFRBeExtMWhkSFJ5TG1kc2IySmhiQ0JTWldGa1pYSWdRWFYwYUdWdWRHbGpZWFJwYjI0d1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFSMDFRd0wxc0dlMjV4Z3Z5cVBMQ3V4TE5HbTVrcDJxbmd3MVEvallGODhwSHI2YVpvZHJaMjF3OXZ0TWFtZE1Vd3k5RlU2WitSMy94S0xobm5LNTF2OG80SUI2RENDQWVRd0hRWURWUjBPQkJZRUZBenpMc2hpaGZJRytheTBVWlgzZW43cVlBRjNNQTRHQTFVZER3RUIvd1FFQXdJSGdEQk1CZ05WSFJJRVJUQkRoa0ZvZEhSd2N6b3ZMMnhoWW5NdGIyNXNhVzVsTFhCeVpYTmxiblJoZEdsdmJpMXpZVzF3YkdVdFlYQndMblpwYVM1aGRUQXhMbTFoZEhSeUxtZHNiMkpoYkRDQmlBWURWUjBSQklHQU1INkdRV2gwZEhCek9pOHZiR0ZpY3kxdmJteHBibVV0Y0hKbGMyVnVkR0YwYVc5dUxYTmhiWEJzWlMxaGNIQXVkbWxwTG1GMU1ERXViV0YwZEhJdVoyeHZZbUZzZ2psc1lXSnpMVzl1YkdsdVpTMXdjbVZ6Wlc1MFlYUnBiMjR0YzJGdGNHeGxMV0Z3Y0M1MmFXa3VZWFV3TVM1dFlYUjBjaTVuYkc5aVlXd3dnWjhHQTFVZEh3U0JsekNCbERDQmthQ0JqcUNCaTRhQmlHaDBkSEJ6T2k4dmJHRmljeTF2Ym14cGJtVXRjSEpsYzJWdWRHRjBhVzl1TFhOaGJYQnNaUzFoY0hBdWRtbHBMbUYxTURFdWJXRjBkSEl1WjJ4dlltRnNMM1l5TDNCeVpYTmxiblJoZEdsdmJuTXZZMlZ5ZEdsbWFXTmhkR1Z6THprMk1tRTNaakJoTFdFek1EUXROREEzWmkxaFlqaG1MV1k0WTJJME5qbGxZVFpoTUM5amNtd3dId1lEVlIwakJCZ3dGb0FVN1Nidlk0cjhsMzhFOGJ0eE1nbk9YbnNaaGVnd0Z3WURWUjBsQVFIL0JBMHdDd1lKS3dZQkJBR0Q0R29DTUFvR0NDcUdTTTQ5QkFNQ0EwY0FNRVFDSUQ3TXRsSXBxaU51Qi91MmtaOEdwcUNNNGRUYXE2aVJnSXlRNkR0NnNxSlhBaUErWFhEK0ZHRGZxcFNPSkNrSE1hcVZDUGwyUTI0MlhNdjh1b3huS3d4RjZnPT0iXX0.eyJhdWQiOiJodHRwczovL3NlbGYtaXNzdWVkLm1lL3YyIiwicmVzcG9uc2VfdHlwZSI6InZwX3Rva2VuIiwicHJlc2VudGF0aW9uX2RlZmluaXRpb24iOnsiaWQiOiJjNWE4NzQ2ZS0wMmIwLTRmYTUtODcyZi02NDQ5YmQ2ZTVjNGEiLCJpbnB1dF9kZXNjcmlwdG9ycyI6W3siaWQiOiJvcmcuaXNvLjE4MDEzLjUuMS5tREwiLCJmb3JtYXQiOnsibXNvX21kb2MiOnsiYWxnIjpbIkVTMjU2Il19fSwiY29uc3RyYWludHMiOnsiZmllbGRzIjpbeyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2ZhbWlseV9uYW1lJ10iXSwiaW50ZW50X3RvX3JldGFpbiI6dHJ1ZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2dpdmVuX25hbWUnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjp0cnVlfSx7InBhdGgiOlsiJFsnb3JnLmlzby4xODAxMy41LjEnXVsnYmlydGhfZGF0ZSddIl0sImludGVudF90b19yZXRhaW4iOnRydWV9LHsicGF0aCI6WyIkWydvcmcuaXNvLjE4MDEzLjUuMSddWydpc3N1ZV9kYXRlJ10iXSwiaW50ZW50X3RvX3JldGFpbiI6dHJ1ZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2V4cGlyeV9kYXRlJ10iXSwiaW50ZW50X3RvX3JldGFpbiI6dHJ1ZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2lzc3VpbmdfY291bnRyeSddIl0sImludGVudF90b19yZXRhaW4iOnRydWV9LHsicGF0aCI6WyIkWydvcmcuaXNvLjE4MDEzLjUuMSddWydpc3N1aW5nX2F1dGhvcml0eSddIl0sImludGVudF90b19yZXRhaW4iOnRydWV9LHsicGF0aCI6WyIkWydvcmcuaXNvLjE4MDEzLjUuMSddWydkb2N1bWVudF9udW1iZXInXSJdLCJpbnRlbnRfdG9fcmV0YWluIjp0cnVlfSx7InBhdGgiOlsiJFsnb3JnLmlzby4xODAxMy41LjEnXVsncG9ydHJhaXQnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjp0cnVlfSx7InBhdGgiOlsiJFsnb3JnLmlzby4xODAxMy41LjEnXVsnZHJpdmluZ19wcml2aWxlZ2VzJ10iXSwiaW50ZW50X3RvX3JldGFpbiI6dHJ1ZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ3VuX2Rpc3Rpbmd1aXNoaW5nX3NpZ24nXSJdLCJpbnRlbnRfdG9fcmV0YWluIjp0cnVlfV0sImxpbWl0X2Rpc2Nsb3N1cmUiOiJyZXF1aXJlZCJ9fV19LCJjbGllbnRfbWV0YWRhdGEiOnsiandrcyI6eyJrZXlzIjpbeyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6Ik5CaDY0NTdPRTFlMk1kSkZWNk9KRGxWdC1UeXZjaU1Tc1RzcHRIdHNFY0kiLCJ5IjoiWE9zMk5OdGtGTkpvXzE5eHZldGhpYnFUM29qNmRpUDVzNXplSnE0NXFmYyIsImtpZCI6ImEyODMwYThlLTFiZjQtNDlmOS04MjNiLTJhZmJhMjU0MmRkMyIsImFsZyI6IkVDREgtRVMiLCJ1c2UiOiJlbmMifV19LCJhdXRob3JpemF0aW9uX2VuY3J5cHRlZF9yZXNwb25zZV9lbmMiOiJBMjU2R0NNIiwiYXV0aG9yaXphdGlvbl9lbmNyeXB0ZWRfcmVzcG9uc2VfYWxnIjoiRUNESC1FUyIsInZwX2Zvcm1hdHMiOnsibXNvX21kb2MiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiIsIkVkRFNBIl19fSwicmVxdWlyZV9zaWduZWRfcmVxdWVzdF9vYmplY3QiOnRydWV9LCJzdGF0ZSI6IjFiNmYyYzdlLTcxZDEtNGE4Ny1iYWIyLTE2MmM3N2FjNjEyYSIsIm5vbmNlIjoiODdZSGNNYm9ZRUVFaUlsZ1YxQ2VkcVNlbzFBVmRReXNjbHFiZHVGUG15MCIsImNsaWVudF9pZCI6ImxhYnMtb25saW5lLXByZXNlbnRhdGlvbi1zYW1wbGUtYXBwLnZpaS5hdTAxLm1hdHRyLmdsb2JhbCIsImNsaWVudF9pZF9zY2hlbWUiOiJ4NTA5X3Nhbl9kbnMiLCJyZXNwb25zZV9tb2RlIjoiZGlyZWN0X3Bvc3Quand0IiwicmVzcG9uc2VfdXJpIjoiaHR0cHM6Ly9sYWJzLW9ubGluZS1wcmVzZW50YXRpb24tc2FtcGxlLWFwcC52aWkuYXUwMS5tYXR0ci5nbG9iYWwvdjIvcHJlc2VudGF0aW9ucy9zZXNzaW9ucy9yZXNwb25zZSJ9.RvoIxCU0xznb-MkUvoSCavj4C60dn8Jn3PVoGGmxBk6kO5Uf2iHfxjb8M4I-hEWs9XxjSBJQolgM5PqFeyXl6A";
+        let authorization_request_object: AuthorizationRequestObject =
+            ssi::claims::jwt::decode_unverified::<UntypedObject>(jwt)
+                .unwrap()
+                .try_into()
+                .unwrap();
+        assert_eq!(
+            authorization_request_object.response_mode,
+            ResponseMode::DirectPostJwt
+        );
+    }
+    #[test]
+    fn deserialize_authorization_request_url() {
+        let url: Url = "mdoc-openid4vp://?client_id=api.verify.spruceid.xyz&request_uri=https%3A%2F%2Fapi.verify.spruceid.xyz%2Fsessions%2Fcadmv%2Frequest%2F0fc25eb0-f845-4733-9c4c-fae695c9c04c".parse().unwrap();
+        let authorization_endpoint: Url = "example://".parse().unwrap();
+        let req = AuthorizationRequest::from_url(url, &authorization_endpoint).unwrap();
+        let expected = RequestIndirection::ByReference("https://api.verify.spruceid.xyz/sessions/cadmv/request/0fc25eb0-f845-4733-9c4c-fae695c9c04c".parse().unwrap());
+        assert_eq!(req.request_indirection, expected);
+    }
+
+    #[test]
+    fn deserialize_authorization_request_url_with_scheme() {
+        let url: Url = "mdoc-openid4vp://?client_id=labs-online-presentation-sample-app.vii.au01.mattr.global&client_id_scheme=x509_san_dns&request_uri=https%3A%2F%2Flabs-online-presentation-sample-app.vii.au01.mattr.global%2Fv2%2Fpresentations%2Fsessions%2Ff7e72833-6f3f-4385-b9dd-3a4ea9453948%2Frequests%2Ff7286044-4c94-4ccf-9956-29a8cc6d0687".parse().unwrap();
+        let authorization_endpoint: Url = "example://".parse().unwrap();
+        let req = AuthorizationRequest::from_url(url, &authorization_endpoint).unwrap();
+        let expected = RequestIndirection::ByReference("https://labs-online-presentation-sample-app.vii.au01.mattr.global/v2/presentations/sessions/f7e72833-6f3f-4385-b9dd-3a4ea9453948/requests/f7286044-4c94-4ccf-9956-29a8cc6d0687".parse().unwrap());
+        assert_eq!(req.request_indirection, expected);
     }
 }

--- a/src/core/object/mod.rs
+++ b/src/core/object/mod.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Value as Json};
 /// An untyped (JSON) Object from which [TypedParameters](TypedParameter) can be parsed.
 ///
 /// Can represent metadata or request objects.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct UntypedObject(pub(crate) Map<String, Json>);
 
 // TODO: Replace anyhow error type.

--- a/src/verifier/request_builder.rs
+++ b/src/verifier/request_builder.rs
@@ -138,7 +138,9 @@ impl<'a> RequestBuilder<'a> {
         let mut initial_status = Status::SentRequest;
 
         let request_indirection = match self.verifier.pass_by_reference.clone() {
-            ByReference::False => RequestIndirection::ByValue(authorization_request_jwt.clone()),
+            ByReference::False => RequestIndirection::ByValue {
+                request: authorization_request_jwt.clone(),
+            },
             ByReference::True { mut at } => {
                 {
                     let Ok(mut path) = at.path_segments_mut() else {
@@ -147,7 +149,7 @@ impl<'a> RequestBuilder<'a> {
                     path.push(&uuid.to_string());
                 }
                 initial_status = Status::SentRequestByReference;
-                RequestIndirection::ByReference(at)
+                RequestIndirection::ByReference { request_uri: at }
             }
         };
 
@@ -158,7 +160,6 @@ impl<'a> RequestBuilder<'a> {
 
         let authorization_request_url = AuthorizationRequest {
             client_id: Some(client_id.0.clone()),
-            client_id_scheme: None,
             request_indirection,
         }
         .to_url(authorization_endpoint)

--- a/src/verifier/request_builder.rs
+++ b/src/verifier/request_builder.rs
@@ -158,6 +158,7 @@ impl<'a> RequestBuilder<'a> {
 
         let authorization_request_url = AuthorizationRequest {
             client_id: Some(client_id.0.clone()),
+            client_id_scheme: None,
             request_indirection,
         }
         .to_url(authorization_endpoint)


### PR DESCRIPTION
If the (now deprecated) `client_id_scheme` is present, the deserialization falls to `RequestIndirection:Direct` which in turns means the request object isn't fetched.