### PR TITLE
Add wasm32 target conditional compilation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ default = []
 # Enables code paths that increase the chance of interoperability with other wallets and verifiers.
 # This should be used with caution in production environments.
 maximize_interoperability = []
+# Enables PKCS#8 support for p256 keys
+pkcs8 = ["p256/pkcs8"]
 
 [dependencies]
 anyhow = "1.0.97"
@@ -25,14 +27,15 @@ http = "1.1.0"
 json-syntax = { version = "0.12.5", features = ["serde_json"] }
 jsonschema = { git = "https://github.com/spruceid/jsonschema.git", branch = "feat/wasm-support" }
 openid4vp-frontend = { version = "0.1.0", path = "openid4vp-frontend" }
-p256 = { version = "0.13.2", features = ["jwk", "pkcs8"] }
+p256 = { version = "0.13.2", features = ["jwk"] }
 rand = { version = "0.8.5" }
+reqwest = { version = "0.12.23", features = ["rustls-tls"] }
 serde = "=1.0.219"
 serde_json = "1.0.107"
 serde_json_path = "0.7.1"
 serde_urlencoded = "0.7.1"
 ssi = { version = "0.12", features = ["secp256r1"] }
-tokio = { version = "1.43.0", features = ["sync"] }
+tokio = { version = "1.43.0" }
 tracing = "0.1.37"
 url = { version = "2.4.1", features = ["serde"] }
 x509-cert = "0.2.4"
@@ -49,4 +52,3 @@ uuid = { version = "1.2", features = ["v4", "serde", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uuid = { version = "1.2", features = ["v4", "serde"] }
-reqwest = { version = "0.12.23", features = ["rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,16 @@ http = "1.1.0"
 # This is currently used in the jwt_vp test to go from a `VeriableCredential` to an `AnyJsonCredential` type.
 # There may be a better way to handle this that doesn't require the `json-syntax` crate directly.
 json-syntax = { version = "0.12.5", features = ["serde_json"] }
-jsonschema = "0.18.0"
+jsonschema = { git = "https://github.com/spruceid/jsonschema.git", branch = "feat/wasm-support" }
 openid4vp-frontend = { version = "0.1.0", path = "openid4vp-frontend" }
-p256 = { version = "0.13.2", features = ["jwk"] }
+p256 = { version = "0.13.2", features = ["jwk", "pkcs8"] }
 rand = { version = "0.8.5" }
-reqwest = { version = "0.12.5", features = ["rustls-tls"] }
-serde = "1.0.188"
+serde = "=1.0.219"
 serde_json = "1.0.107"
 serde_json_path = "0.7.1"
 serde_urlencoded = "0.7.1"
 ssi = { version = "0.12", features = ["secp256r1"] }
-tokio = "1.32.0"
+tokio = { version = "1.43.0", features = ["sync"] }
 tracing = "0.1.37"
 url = { version = "2.4.1", features = ["serde"] }
 x509-cert = "0.2.4"
@@ -42,7 +41,7 @@ thiserror = "1.0.65"
 [dev-dependencies]
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_path_to_error = "0.1.8"
-tokio = { version = "1.32.0", features = ["macros"] }
+tokio = { version = "1.43.0", features = ["macros"] }
 did-method-key = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -50,3 +49,4 @@ uuid = { version = "1.2", features = ["v4", "serde", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uuid = { version = "1.2", features = ["v4", "serde"] }
+reqwest = { version = "0.12.23", features = ["rustls-tls"] }

--- a/src/core/input_descriptor.rs
+++ b/src/core/input_descriptor.rs
@@ -272,12 +272,15 @@ impl Constraints {
 #[derive(Debug, Clone)]
 pub struct CompiledJsonSchema {
     raw: serde_json::Value,
-    compiled: Arc<jsonschema::JSONSchema>,
+    compiled: Arc<jsonschema::Resource>,
 }
 
 impl CompiledJsonSchema {
-    pub fn validator(&self) -> &Arc<jsonschema::JSONSchema> {
-        &self.compiled
+    pub fn validator(&self) -> Arc<jsonschema::Validator> {
+        let validator = jsonschema::validator_for(self.compiled.contents())
+            // Safety: the compiled contents should always be valid json schema
+            .unwrap();
+        Arc::new(validator)
     }
 }
 
@@ -291,7 +294,7 @@ impl<'a> TryFrom<&'a serde_json::Value> for CompiledJsonSchema {
     type Error = ValidationError<'a>;
 
     fn try_from(value: &'a serde_json::Value) -> Result<Self, Self::Error> {
-        let compiled = jsonschema::JSONSchema::compile(value)?;
+        let compiled = jsonschema::Resource::from_contents(value.to_owned())?;
         Ok(Self {
             raw: value.to_owned(),
             compiled: Arc::new(compiled),
@@ -325,7 +328,7 @@ impl<'de> Deserialize<'de> for CompiledJsonSchema {
     {
         let raw = serde_json::Value::deserialize(deserializer)?;
 
-        let compiled = jsonschema::JSONSchema::compile(&raw)
+        let compiled = jsonschema::Resource::from_contents(raw.clone())
             .map(Arc::new)
             .map_err(|e| serde::de::Error::custom(format!("Failed to compile JSON schema: {e}")))?;
 
@@ -445,7 +448,7 @@ impl ConstraintsField {
     /// If present its value MUST be a JSON Schema descriptor used to filter against
     /// the values returned from evaluation of the JSONPath string expressions in the path array.
     #[allow(clippy::result_large_err)]
-    pub fn set_filter(mut self, filter: &serde_json::Value) -> Result<Self, ValidationError> {
+    pub fn set_filter(mut self, filter: &serde_json::Value) -> Result<Self, ValidationError<'_>> {
         self.filter = Some(CompiledJsonSchema::try_from(filter)?);
         Ok(self)
     }

--- a/src/core/presentation_submission.rs
+++ b/src/core/presentation_submission.rs
@@ -93,7 +93,7 @@ impl PresentationSubmission {
         definition: &PresentationDefinition,
         value: &serde_json::Value,
         decoder: &impl ClaimsDecoder<T>,
-    ) -> Result<MatchingInputs<T>, SubmissionError> {
+    ) -> Result<MatchingInputs<'_, T>, SubmissionError> {
         let mut inputs = Vec::new();
         for d in &self.descriptor_map {
             d.find_inputs(definition, value, decoder, &mut inputs)?;
@@ -120,7 +120,7 @@ impl PresentationSubmission {
         definition: &PresentationDefinition,
         value: &serde_json::Value,
         decoder: &impl ClaimsDecoder<T>,
-    ) -> Result<MatchingInputs<T>, SubmissionError> {
+    ) -> Result<MatchingInputs<'_, T>, SubmissionError> {
         let matches = self.find_inputs(definition, value, decoder)?;
         matches.validate(definition)?;
         Ok(matches)

--- a/src/core/response/parameters.rs
+++ b/src/core/response/parameters.rs
@@ -59,7 +59,7 @@ impl VpToken {
         self.0.len()
     }
 
-    pub fn iter(&self) -> std::slice::Iter<VpTokenItem> {
+    pub fn iter(&self) -> std::slice::Iter<'_, VpTokenItem> {
         self.0.iter()
     }
 }

--- a/src/verifier/client.rs
+++ b/src/verifier/client.rs
@@ -20,7 +20,8 @@ use crate::core::authorization_request::{
 
 use super::request_signer::RequestSigner;
 
-#[async_trait]
+#[cfg_attr(target_arch="wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait Client: Debug {
     fn id(&self) -> &ClientId;
 
@@ -140,7 +141,8 @@ impl X509SanVariant {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch="wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl Client for DIDClient {
     fn id(&self) -> &ClientId {
         &self.id
@@ -167,7 +169,8 @@ impl Client for DIDClient {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch="wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl Client for X509SanClient {
     fn id(&self) -> &ClientId {
         &self.id

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -23,11 +23,14 @@ pub mod session;
 /// An OpenID4VP verifier, also known as the client.
 #[derive(Debug, Clone)]
 pub struct Verifier {
-    client: Arc<dyn Client + Send + Sync>,
-    default_request_params: UntypedObject,
-    pass_by_reference: ByReference,
-    session_store: Arc<dyn SessionStore + Send + Sync>,
-    submission_endpoint: Url,
+    pub client: Arc<dyn Client + Send + Sync>,
+    pub default_request_params: UntypedObject,
+    pub pass_by_reference: ByReference,
+    #[cfg(target_arch = "wasm32")]
+    pub session_store: Arc<dyn SessionStore>,
+    #[cfg(not(target_arch = "wasm32"))]
+    pub session_store: Arc<dyn SessionStore + Send + Sync>,
+    pub submission_endpoint: Url,
 }
 
 impl Verifier {
@@ -138,6 +141,9 @@ pub struct VerifierBuilder {
     client: Option<Arc<dyn Client + Send + Sync>>,
     default_request_params: UntypedObject,
     pass_by_reference: ByReference,
+    #[cfg(target_arch = "wasm32")]
+    session_store: Option<Arc<dyn SessionStore>>,
+    #[cfg(not(target_arch = "wasm32"))]
     session_store: Option<Arc<dyn SessionStore + Send + Sync>>,
     submission_endpoint: Option<Url>,
 }
@@ -208,7 +214,8 @@ impl VerifierBuilder {
     /// will use to maintain session state across transactions.
     pub fn with_session_store(
         mut self,
-        session_store: Arc<dyn SessionStore + Send + Sync>,
+        #[cfg(target_arch = "wasm32")] session_store: Arc<dyn SessionStore>,
+        #[cfg(not(target_arch = "wasm32"))] session_store: Arc<dyn SessionStore + Send + Sync>,
     ) -> Self {
         self.session_store = Some(session_store);
         self

--- a/src/verifier/request_builder.rs
+++ b/src/verifier/request_builder.rs
@@ -193,9 +193,7 @@ impl<'a> RequestBuilder<'a> {
         Ok(authorization_request_url)
     }
 
-    pub async fn build_dc_api(mut self) -> Result<(Uuid, String)> {
-        let uuid = Uuid::new_v4();
-
+    pub async fn build_dc_api_with_session_id(mut self, uuid: Uuid) -> Result<(Uuid, String)> {
         let client_id = self.verifier.client.id();
         let client_id_scheme = self.verifier.client.scheme();
 
@@ -263,5 +261,9 @@ impl<'a> RequestBuilder<'a> {
             .context("failed to store the session in the session store")?;
 
         Ok((uuid, authorization_request_jwt))
+    }
+
+    pub async fn build_dc_api(self) -> Result<(Uuid, String)> {
+        self.build_dc_api_with_session_id(Uuid::new_v4()).await
     }
 }

--- a/src/verifier/request_signer.rs
+++ b/src/verifier/request_signer.rs
@@ -1,14 +1,16 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use p256::ecdsa::{signature::Signer, Signature, SigningKey};
+use p256::pkcs8::DecodePrivateKey;
 use ssi::claims::jws::{JwsSigner, JwsSignerInfo};
 use ssi::jwk::Algorithm;
 
-use ssi::jwk::JWK;
+pub use ssi::jwk::JWK;
 
 use std::fmt::Debug;
 
-#[async_trait]
+#[cfg_attr(target_arch="wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait RequestSigner: Debug {
     type Error: std::fmt::Display;
 
@@ -42,12 +44,22 @@ impl P256Signer {
         Ok(Self { key, jwk })
     }
 
+    pub fn from_pkcs8_pem(s: &str) -> Result<Self> {
+        let key = p256::SecretKey::from_pkcs8_pem(s)?;
+        let jwk = serde_json::from_str(&key.to_jwk_string())?;
+        Ok(Self {
+            key: key.into(),
+            jwk,
+        })
+    }
+
     pub fn jwk(&self) -> &JWK {
         &self.jwk
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch="wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl RequestSigner for P256Signer {
     type Error = anyhow::Error;
 
@@ -81,5 +93,26 @@ impl JwsSigner for P256Signer {
         self.try_sign(signing_bytes)
             .await
             .map_err(|e| ssi::claims::SignatureError::Other(format!("Failed to sign bytes: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::verifier::request_signer::P256Signer;
+    use anyhow::Result;
+
+    #[test]
+    fn test_p25_from_pkcs8_pem() -> Result<()> {
+        let pem = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgpuJEtk8m2LIgMcZy
+pbrD0ECdHI3UzCnImDfRYydCvFShRANCAARmahl0HOSy+6nH91+Alxe+BF/va3jI
+1jSnv8o+7a2nhvU3XKDFLlCR1MBjoJTjy92+H3hPMw3FRFcTamaXA+Co
+-----END PRIVATE KEY-----"#;
+
+        let key = P256Signer::from_pkcs8_pem(pem)?;
+
+        println!("JWK: {}", key.jwk());
+
+        Ok(())
     }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -13,9 +13,14 @@ use crate::core::{
     util::{base_request, AsyncHttpClient},
 };
 
-#[async_trait]
+#[cfg_attr(target_arch="wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait Wallet: RequestVerifier + Sync {
+    #[cfg(not(target_arch = "wasm32"))]
     type HttpClient: AsyncHttpClient + Send + Sync;
+
+    #[cfg(target_arch = "wasm32")]
+    type HttpClient: AsyncHttpClient;
 
     fn metadata(&self) -> &WalletMetadata;
     fn http_client(&self) -> &Self::HttpClient;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,4 +1,3 @@
-#![cfg(not(target_arch = "wasm32"))]
 use jwt_vp::create_test_verifiable_presentation;
 use openid4vp::{
     core::{

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
 use jwt_vp::create_test_verifiable_presentation;
 use openid4vp::{
     core::{

--- a/tests/jwt_vc.rs
+++ b/tests/jwt_vc.rs
@@ -1,4 +1,3 @@
-#![cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
@@ -148,7 +147,8 @@ impl RequestVerifier for JwtVcWallet {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch="wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AsyncHttpClient for MockHttpClient {
     async fn execute(&self, request: Request<Vec<u8>>) -> Result<Response<Vec<u8>>> {
         // Only expect submission.

--- a/tests/jwt_vc.rs
+++ b/tests/jwt_vc.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};


### PR DESCRIPTION
This pull request introduces updates to enable WASM compatibility. The most important changes include updating dependencies (notably `jsonschema`, `serde`, `tokio`, and `reqwest`), refactoring for WASM support (including conditional compilation and trait adjustments), and improving the handling and validation of JSON schemas.

**Dependency Updates and WASM Compatibility:**

* Updated dependencies in `Cargo.toml` to use a WASM-compatible fork of `jsonschema`, newer versions of `serde`, `tokio` (with appropriate features), and separated `reqwest` dependencies for WASM and non-WASM targets. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R35) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L45-R52)
* Refactored trait and struct definitions throughout the codebase to use conditional compilation and `async_trait` attributes for WASM compatibility, including in `Client`, `RequestSigner`, and `SessionStore` traits. [[1]](diffhunk://#diff-56a7093167d0cc442d400d54bb4b19762e71558f7e32b978cc2876583c809181L23-R24) [[2]](diffhunk://#diff-56a7093167d0cc442d400d54bb4b19762e71558f7e32b978cc2876583c809181L143-R145) [[3]](diffhunk://#diff-56a7093167d0cc442d400d54bb4b19762e71558f7e32b978cc2876583c809181L170-R173) [[4]](diffhunk://#diff-2995f755409dd8f418ae2e70c95b2de026ba584dbe531390a00409d2f65012a1R4-R13) [[5]](diffhunk://#diff-7dfcb5d4620561d203d4ed2be584ad8f6beb4766095682b4b371f9bc02e32919L25-R28) [[6]](diffhunk://#diff-7dfcb5d4620561d203d4ed2be584ad8f6beb4766095682b4b371f9bc02e32919R48-R56)

**JSON Schema Handling Improvements:**

* Switched from using `jsonschema::JSONSchema` to `jsonschema::Resource` given interface changes, and updated related methods to use the new validator construction pattern. [[1]](diffhunk://#diff-fa46d07364131a9f9a219c0638bb79292c318fe6cd213ff166a389303bd5d2baL275-R283) [[2]](diffhunk://#diff-fa46d07364131a9f9a219c0638bb79292c318fe6cd213ff166a389303bd5d2baL294-R297) [[3]](diffhunk://#diff-fa46d07364131a9f9a219c0638bb79292c318fe6cd213ff166a389303bd5d2baL328-R331) [[4]](diffhunk://#diff-fa46d07364131a9f9a219c0638bb79292c318fe6cd213ff166a389303bd5d2baL448-R451)

**Session and Verifier Refactoring:**

* Made `Verifier` struct fields public and adjusted `SessionStore` trait and builder patterns to support both WASM and non-WASM targets, improving flexibility and testability. [[1]](diffhunk://#diff-255a75105edceafa98665f33d02fd54a26ae1fb9e3918d7e8966ac3f9a27f0a5L26-R33) [[2]](diffhunk://#diff-255a75105edceafa98665f33d02fd54a26ae1fb9e3918d7e8966ac3f9a27f0a5R144-R146) [[3]](diffhunk://#diff-255a75105edceafa98665f33d02fd54a26ae1fb9e3918d7e8966ac3f9a27f0a5L211-R218)
* Modularized the in-memory session store for non-WASM targets and added serialization support for `Session`. [[1]](diffhunk://#diff-7dfcb5d4620561d203d4ed2be584ad8f6beb4766095682b4b371f9bc02e32919L1-R7) [[2]](diffhunk://#diff-7dfcb5d4620561d203d4ed2be584ad8f6beb4766095682b4b371f9bc02e32919L14-R16) [[3]](diffhunk://#diff-7dfcb5d4620561d203d4ed2be584ad8f6beb4766095682b4b371f9bc02e32919R48-R56) [[4]](diffhunk://#diff-7dfcb5d4620561d203d4ed2be584ad8f6beb4766095682b4b371f9bc02e32919R94-R97)

**HTTP Client Abstraction:**

* Refactored HTTP client code to provide a WASM-compatible interface, moving client implementation behind conditional compilation and improving error handling. [[1]](diffhunk://#diff-5b1a90214dd0254b645bbe07e4410461fcfe0725f07388e2b2b8718d35c41d1dL1) [[2]](diffhunk://#diff-5b1a90214dd0254b645bbe07e4410461fcfe0725f07388e2b2b8718d35c41d1dR17-R24) [[3]](diffhunk://#diff-5b1a90214dd0254b645bbe07e4410461fcfe0725f07388e2b2b8718d35c41d1dL29-R40) [[4]](diffhunk://#diff-5b1a90214dd0254b645bbe07e4410461fcfe0725f07388e2b2b8718d35c41d1dR78)

**Cryptographic Enhancements and Testing:**

* Added a helper method to `P256Signer` for constructing from PKCS#8 PEM, and included a corresponding test to verify its functionality. [[1]](diffhunk://#diff-2995f755409dd8f418ae2e70c95b2de026ba584dbe531390a00409d2f65012a1R47-R62) [[2]](diffhunk://#diff-2995f755409dd8f418ae2e70c95b2de026ba584dbe531390a00409d2f65012a1R98-R118)

**Test Suite Adjustments:**

* Updated test files to exclude execution on WASM targets, ensuring tests only run where supported. [[1]](diffhunk://#diff-62403d73a2340f1d6ac792a3d62161b538ffefa05bc7365f96351854116d63b1R1) [[2]](diffhunk://#diff-a818dff7f5f57fab31b5e2af636b1241f4a50f929b61b2ad75a37aec3642e68fR1)