### PR TITLE
Update conformance tests according to OIDF OID4VP 1.0/HAIP 1.0 tests

### DIFF
--- a/examples/verifier-conformance-adapter/README.md
+++ b/examples/verifier-conformance-adapter/README.md
@@ -1,12 +1,13 @@
 # OID4VP Verifier Adapter
 
-Verifier implementation for OpenID for Verifiable Presentations (OID4VP) 1.0 conformance testing. Uses `x509_san_dns` client ID scheme with self-signed certificates.
+Verifier implementation for OpenID for Verifiable Presentations (OID4VP) 1.0 conformance testing. Uses the `x509_san_dns` client ID scheme with a CA-signed leaf certificate.
 
 ## Features
 
-- **X.509 SAN DNS**: Self-signed certificate with domain as SAN
+- **X.509 SAN DNS**: Leaf certificate (domain as SAN) signed by a self-signed CA. Only the leaf is sent in `x5c`; the CA is provided to the suite as the request object trust anchor.
 - **DCQL queries**: Requests SD-JWT VC credentials
 - **Response modes**: `direct_post` and `direct_post.jwt` (JWE encrypted)
+- **Response verification**: Minimal SD-JWT VC checks (issuer signature, KB-JWT signature, `sd_hash`, `nonce`, `aud`, `iat` freshness); rejects invalid presentations with a 4xx
 - **Certificate caching**: Reuses certificates for the same domain
 
 ## Quick Start
@@ -25,6 +26,9 @@ cargo run --example verifier-conformance-adapter -- --public-url https://YOUR_NG
 
 # For direct_post.jwt (encrypted)
 cargo run --example verifier-conformance-adapter -- --public-url https://YOUR_NGROK_URL.ngrok-free.app --response-mode direct_post.jwt
+
+# For the HAIP profile (x509_hash client ID + encrypted response)
+cargo run --example verifier-conformance-adapter -- --public-url https://YOUR_NGROK_URL.ngrok-free.app --response-mode direct_post.jwt --client-id-prefix x509_hash
 ```
 
 The adapter prints the signing key configuration on startup - you'll need this for the OIDF test setup.
@@ -41,12 +45,23 @@ Go to https://demo.certification.openid.net/ and create a new test plan.
 
 ### Test Configuration
 
-| Field | Value |
-|-------|-------|
-| **Test Plan** | `OpenID for Verifiable Presentations 1.0 Final: Test a verifier` |
-| **Credential Format** | `sd_jwt_vc` |
-| **Client Id Scheme** | `x509_san_dns` |
-| **Response Mode** | `direct_post` or `direct_post.jwt` |
+| Field                 | Value                                                            |
+| --------------------- | ---------------------------------------------------------------- |
+| **Test Plan**         | `OpenID for Verifiable Presentations 1.0 Final: Test a verifier` |
+| **Credential Format** | `sd_jwt_vc`                                                      |
+| **Client Id Scheme**  | `x509_san_dns` (base) or `x509_hash` (HAIP)                      |
+| **Response Mode**     | `direct_post` or `direct_post.jwt`                               |
+| **VP Profile**        | `plain_vp` (base) or `haip`                                      |
+
+### HAIP profile
+
+For the `haip` VP profile, run with `--client-id-prefix x509_hash --response-mode direct_post.jwt`. This makes the adapter:
+
+- use the `x509_hash` Client Identifier Prefix (`client_id = x509_hash:<base64url SHA-256 of the leaf cert>`), as HAIP Section 5 mandates;
+- advertise `encrypted_response_enc_values_supported: ["A128GCM", "A256GCM"]` in `client_metadata` (required by HAIP Section 5);
+- send encrypted responses via `direct_post.jwt`.
+
+The `request_object_trust_anchor_pem` (see below) is still required so the suite can validate the leaf certificate's chain.
 
 ### Sample Configuration
 
@@ -54,28 +69,45 @@ Use the values printed by the adapter on startup:
 
 ```json
 {
-    "alias": "my-verifier-oid4vp1",
-    "description": "OID4VP 1.0 Final verifier conformance - SD-JWT VC, x509_san_dns, request_uri_signed, direct_post",
-    "client": {
-        "client_id": "YOUR_NGROK_URL.ngrok-free.app"
-    },
-    "credential": {
-        "signing_jwk": {
-            "kty": "EC",
-            "crv": "P-256",
-            "use": "sig",
-            "alg": "ES256",
-            "x": "<from adapter output>",
-            "y": "<from adapter output>",
-            "d": "<from adapter output>",
-            "x5c": ["<from adapter output>"]
-        }
-    },
-    "federation": {
-        "trust_anchor": "https://demo.certification.openid.net/test/a/my-verifier-oid4vp1/trust-anchor"
+  "alias": "my-verifier-oid4vp1",
+  "description": "OID4VP 1.0 Final verifier conformance - SD-JWT VC, x509_san_dns, request_uri_signed, direct_post",
+  "client": {
+    "client_id": "YOUR_NGROK_URL.ngrok-free.app",
+    "request_object_trust_anchor_pem": "<from adapter output>"
+  },
+  "credential": {
+    "signing_jwk": {
+      "kty": "EC",
+      "crv": "P-256",
+      "use": "sig",
+      "alg": "ES256",
+      "x": "<from adapter output>",
+      "y": "<from adapter output>",
+      "d": "<from adapter output>",
+      "x5c": ["<from adapter output>"]
     }
+  },
+  "federation": {
+    "trust_anchor": "https://demo.certification.openid.net/test/a/my-verifier-oid4vp1/trust-anchor"
+  }
 }
 ```
+
+#### `request_object_trust_anchor_pem`
+
+The trust anchor certificate (PEM) the suite uses to verify the x5c chain of the
+verifier's signed request object. **Required for HAIP.**
+
+The adapter signs the request object with a leaf certificate (sent in the `x5c`
+header) that is issued by a self-signed CA. That CA is the trust anchor: the
+adapter prints it on startup as a ready-to-paste JSON property. Because this is a
+JSON string value, the newlines are escaped as `\n` (the suite un-escapes them
+when parsing) — this is expected, not a formatting bug.
+
+The CA is cached per domain (`.cache/certs/<domain>.json`), so it stays stable
+across restarts. If the public URL (domain) changes, the leaf and CA are
+regenerated, so re-copy **both** the `signing_jwk` and
+`request_object_trust_anchor_pem` from the banner.
 
 ## Running Tests (Manual Flow)
 
@@ -94,6 +126,7 @@ curl -s -X POST https://YOUR_NGROK_URL.ngrok-free.app/initiate \
 ```
 
 Response:
+
 ```json
 {
   "session_id": "550e8400-e29b-41d4-a716-446655440000",
@@ -120,13 +153,13 @@ Go back to the OIDF conformance tool and check if the test passed.
 
 ## Endpoints
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/initiate` | POST | Start a new authorization request |
-| `/request/{session_id}` | GET | Wallet fetches the signed request JWT |
-| `/response/{session_id}` | POST | Wallet submits the VP token |
-| `/status/{session_id}` | GET | Check session status |
-| `/health` | GET | Health check |
+| Endpoint                 | Method | Description                           |
+| ------------------------ | ------ | ------------------------------------- |
+| `/initiate`              | POST   | Start a new authorization request     |
+| `/request/{session_id}`  | GET    | Wallet fetches the signed request JWT |
+| `/response/{session_id}` | POST   | Wallet submits the VP token           |
+| `/status/{session_id}`   | GET    | Check session status                  |
+| `/health`                | GET    | Health check                          |
 
 ## Development
 

--- a/examples/verifier-conformance-adapter/main.rs
+++ b/examples/verifier-conformance-adapter/main.rs
@@ -34,6 +34,10 @@ struct Args {
     /// Response mode: "direct_post" or "direct_post.jwt"
     #[arg(long, default_value = "direct_post", env = "RESPONSE_MODE")]
     response_mode: String,
+
+    /// Client Identifier Prefix: "x509_san_dns" or "x509_hash" (HAIP requires x509_hash)
+    #[arg(long, default_value = "x509_san_dns", env = "CLIENT_ID_PREFIX")]
+    client_id_prefix: String,
 }
 
 #[tokio::main]
@@ -50,7 +54,14 @@ async fn main() -> Result<()> {
 
     let use_encrypted_response = args.response_mode == "direct_post.jwt";
 
-    let state = Arc::new(AppState::new(args.public_url.clone(), use_encrypted_response).await?);
+    let state = Arc::new(
+        AppState::new(
+            args.public_url.clone(),
+            use_encrypted_response,
+            &args.client_id_prefix,
+        )
+        .await?,
+    );
 
     print_startup_banner(&args, &state.oidf_config);
 
@@ -96,5 +107,12 @@ fn print_startup_banner(args: &Args, oidf: &OidfConfig) {
     println!("  \"x5c\": [\"{}\"]", oidf.x5c);
     println!("}}");
     println!();
+    println!("  Add this property to your JSON test configuration");
+    println!("  (the \\n escapes are required - it is a JSON string value):");
+    println!();
+    println!(
+        "  \"request_object_trust_anchor_pem\": \"{}\"",
+        oidf.trust_anchor_pem.trim_end().replace('\n', "\\n")
+    );
     println!();
 }

--- a/examples/verifier-conformance-adapter/server/handlers.rs
+++ b/examples/verifier-conformance-adapter/server/handlers.rs
@@ -17,6 +17,7 @@ use openid4vp::{
 use serde::{Deserialize, Serialize};
 use ssi::claims::jws::{decode_unverified, decode_verify};
 use ssi::claims::sd_jwt::{KbJwtPayload, SdAlg, SdJwt};
+use ssi::claims::{DateTimeProvider, ValidateClaims};
 use ssi::jwk::JWK;
 use tracing::{debug, error, info};
 use uuid::Uuid;
@@ -325,24 +326,34 @@ fn verify_sd_jwt_vc(
         return Err("KB-JWT sd_hash does not match the presented SD-JWT".into());
     }
 
-    // The KB-JWT must be fresh: `iat` cannot be in the future (beyond clock
-    // skew) nor too far in the past. The window is intentionally generous; tune
-    // it if the conformance suite uses a smaller offset.
-    const CLOCK_SKEW_SECS: f64 = 60.0;
+    // Validate the KB-JWT time claims via its own `ValidateClaims` impl
+    // (rejects `iat` in the future, plus `exp`/`nbf` when present).
+    kb.validate_claims(&Now, &())
+        .map_err(|e| format!("KB-JWT time claims are invalid: {e}"))?;
+
+    // `ssi` only checks that `iat` is not in the future. The maximum age ("iat too
+    // far in the past") is verifier policy, so we enforce it here.
     const MAX_AGE_SECS: f64 = 300.0;
     let iat = kb.iat.0.as_seconds();
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| format!("system clock error: {e}"))?
         .as_secs() as f64;
-    if iat > now + CLOCK_SKEW_SECS {
-        return Err("KB-JWT iat is in the future".into());
-    }
     if iat < now - MAX_AGE_SECS {
         return Err("KB-JWT iat is too far in the past".into());
     }
 
     Ok(())
+}
+
+/// Minimal [`DateTimeProvider`] supplying the current time so `ssi` can validate
+/// the KB-JWT time claims against "now".
+struct Now;
+
+impl DateTimeProvider for Now {
+    fn date_time(&self) -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc::now()
+    }
 }
 
 /// Build a P-256 JWK from the leaf certificate of a JWS `x5c` header.

--- a/examples/verifier-conformance-adapter/server/handlers.rs
+++ b/examples/verifier-conformance-adapter/server/handlers.rs
@@ -6,13 +6,21 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use base64::prelude::*;
 use openid4vp::{
-    core::{authorization_request::parameters::Nonce, response::AuthorizationResponse},
-    verifier::session::{Outcome, Status},
+    core::{
+        authorization_request::parameters::Nonce,
+        response::{parameters::VpTokenItem, AuthorizationResponse},
+    },
+    verifier::session::{Outcome, Session, Status},
 };
 use serde::{Deserialize, Serialize};
+use ssi::claims::jws::{decode_unverified, decode_verify};
+use ssi::claims::sd_jwt::{KbJwtPayload, SdAlg, SdJwt};
+use ssi::jwk::JWK;
 use tracing::{debug, error, info};
 use uuid::Uuid;
+use x509_cert::{der::Decode, Certificate};
 
 use super::AppState;
 use crate::crypto::decrypt_jwe;
@@ -143,72 +151,45 @@ pub async fn receive_response(
 
     info!("Parsed authorization response successfully");
 
-    // Clone the encryption key for use in the closure
+    // Clone the encryption key for use in the closure.
     let encryption_key = state.encryption_key_jwk.clone();
+
+    // The validator runs inside `verify_response`, but its `Outcome` is only
+    // stored in the session. We capture the rejection reason here so the HTTP
+    // handler can return a 4xx, as required by OID4VP 1.0 Section 8.2.
+    let rejection: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+    let rejection_cb = rejection.clone();
 
     state
         .verifier
-        .verify_response(uuid, authorization_response, |session, response| {
+        .verify_response(uuid, authorization_response, move |session, response| {
             Box::pin(async move {
-                // For conformance testing, we do basic validation
-                // In production, you would verify signatures, check claims, etc.
                 info!("Validating response for session: {}", session.uuid);
 
-                match &response {
+                let result = match &response {
                     AuthorizationResponse::Unencoded(unencoded) => {
-                        let vp_token = &unencoded.vp_token;
-                        info!(
-                            "Received unencoded vp_token with {} credential(s)",
-                            vp_token.0.len()
-                        );
-
-                        for (query_id, presentations) in &vp_token.0 {
-                            info!(
-                                "Query '{}': {} presentation(s)",
-                                query_id,
-                                presentations.len()
-                            );
-                        }
-
-                        Outcome::Success {
-                            info: serde_json::json!({
-                                "message": "Verification successful",
-                                "credentials_received": vp_token.0.len()
-                            }),
-                        }
+                        verify_string_presentations(&session, &unencoded.vp_token.0)
                     }
                     AuthorizationResponse::Jwt(jwt_response) => {
-                        // For direct_post.jwt mode - decrypt the JWE
                         info!("Received encrypted JWT response (JARM)");
-                        debug!("JWE: {}", jwt_response.response);
-
                         match decrypt_jwe(&jwt_response.response, &encryption_key) {
-                            Ok(decrypted) => {
-                                info!("Successfully decrypted JARM response");
-                                debug!("Decrypted payload: {:?}", decrypted);
-
-                                // Extract vp_token from decrypted payload
-                                if let Some(vp_token) = decrypted.get("vp_token") {
-                                    info!(
-                                        "Extracted vp_token from decrypted response: {:?}",
-                                        vp_token
-                                    );
-                                }
-
-                                Outcome::Success {
-                                    info: serde_json::json!({
-                                        "message": "JARM response decrypted and verified",
-                                        "decrypted_payload": decrypted
-                                    }),
-                                }
-                            }
-                            Err(e) => {
-                                error!("Failed to decrypt JARM response: {}", e);
-                                Outcome::Error {
-                                    cause: format!("Failed to decrypt JARM: {}", e),
-                                }
-                            }
+                            Ok(decrypted) => verify_decrypted_vp_token(&session, &decrypted),
+                            Err(e) => Err(format!("failed to decrypt JARM response: {e}")),
                         }
+                    }
+                };
+
+                match result {
+                    Ok(count) => Outcome::Success {
+                        info: serde_json::json!({
+                            "message": "Verification successful",
+                            "credentials_verified": count
+                        }),
+                    },
+                    Err(reason) => {
+                        error!("Rejecting response: {}", reason);
+                        *rejection_cb.lock().unwrap() = Some(reason.clone());
+                        Outcome::Failure { reason }
                     }
                 }
             })
@@ -219,9 +200,181 @@ pub async fn receive_response(
             AppError::Internal(format!("Verification failed: {}", e))
         })?;
 
+    if let Some(reason) = rejection.lock().unwrap().take() {
+        return Err(AppError::BadRequest(reason));
+    }
+
     info!("Authorization response verified successfully");
 
     Ok(Json(serde_json::json!({})))
+}
+
+/// Verify every string presentation in an unencoded `vp_token`.
+///
+/// Returns the number of verified credentials, or a rejection reason.
+fn verify_string_presentations(
+    session: &Session,
+    vp_token: &std::collections::HashMap<String, Vec<VpTokenItem>>,
+) -> Result<usize, String> {
+    let (nonce, aud) = request_binding(session);
+    let mut count = 0;
+    for (query_id, presentations) in vp_token {
+        for item in presentations {
+            let VpTokenItem::String(sd_jwt) = item else {
+                return Err(format!(
+                    "query '{query_id}': unsupported presentation format"
+                ));
+            };
+            verify_sd_jwt_vc(sd_jwt, &nonce, &aud)?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+/// Verify the string presentations carried in a decrypted (JARM) `vp_token`.
+fn verify_decrypted_vp_token(
+    session: &Session,
+    decrypted: &serde_json::Value,
+) -> Result<usize, String> {
+    let (nonce, aud) = request_binding(session);
+    let vp_token = decrypted
+        .get("vp_token")
+        .and_then(|v| v.as_object())
+        .ok_or("decrypted response has no vp_token object")?;
+    let mut count = 0;
+    for (query_id, presentations) in vp_token {
+        let arr = presentations
+            .as_array()
+            .ok_or_else(|| format!("query '{query_id}': presentations is not an array"))?;
+        for item in arr {
+            let sd_jwt = item
+                .as_str()
+                .ok_or_else(|| format!("query '{query_id}': unsupported presentation format"))?;
+            verify_sd_jwt_vc(sd_jwt, &nonce, &aud)?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+/// Extract the expected `nonce` and `aud` (client_id) from the request session.
+fn request_binding(session: &Session) -> (String, String) {
+    let nonce = session.authorization_request_object.nonce().to_string();
+    let aud = session
+        .authorization_request_object
+        .client_id()
+        .map(|c| c.0.clone())
+        .unwrap_or_default();
+    (nonce, aud)
+}
+
+/// Minimal SD-JWT VC + Key Binding JWT verification using `ssi`.
+///
+/// Checks the essentials needed to reject forged or mis-bound presentations:
+/// - the credential is a well-formed SD-JWT VC ending in a Key Binding JWT;
+/// - the issuer JWT signature is valid against the public key in its `x5c` leaf
+///   certificate (this is what the `invalid-credential-signature` test corrupts);
+/// - the KB-JWT signature is valid against the holder key in the issuer JWT's
+///   `cnf` claim (this is what the `invalid-kb-jwt-signature` test corrupts);
+/// - the KB-JWT `nonce` and `aud` match the Authorization Request.
+fn verify_sd_jwt_vc(
+    presentation: &str,
+    expected_nonce: &str,
+    expected_aud: &str,
+) -> Result<(), String> {
+    let sd_jwt = SdJwt::new(presentation).map_err(|e| format!("invalid SD-JWT: {e}"))?;
+    let issuer_jwt = sd_jwt.jwt().as_str();
+
+    // Decode the issuer JWT header (for the x5c key) and verify its signature.
+    let (header, _) =
+        decode_unverified(issuer_jwt).map_err(|e| format!("failed to decode issuer JWT: {e}"))?;
+    let issuer_key = issuer_key_from_x5c(&header.x509_certificate_chain)?;
+    let (_, payload) = decode_verify(issuer_jwt, &issuer_key)
+        .map_err(|e| format!("issuer SD-JWT signature verification failed: {e}"))?;
+
+    // Recover the holder key from the issuer JWT's `cnf.jwk`.
+    let claims: serde_json::Value = serde_json::from_slice(&payload)
+        .map_err(|e| format!("issuer JWT payload not JSON: {e}"))?;
+    let cnf_jwk = claims
+        .get("cnf")
+        .and_then(|c| c.get("jwk"))
+        .ok_or("issuer JWT has no cnf.jwk (holder key)")?;
+    let holder_key: JWK =
+        serde_json::from_value(cnf_jwk.clone()).map_err(|e| format!("invalid cnf.jwk: {e}"))?;
+
+    // Verify the KB-JWT signature against the holder key, then deserialize the
+    // typed KB-JWT payload (ssi `KbJwtPayload`).
+    let kb_jwt = sd_jwt.kb().ok_or("Key Binding JWT is missing")?.as_str();
+    let (_, kb_payload) = decode_verify(kb_jwt, &holder_key)
+        .map_err(|e| format!("Key Binding JWT signature verification failed: {e}"))?;
+    let kb: KbJwtPayload = serde_json::from_slice(&kb_payload)
+        .map_err(|e| format!("KB-JWT is not a valid Key Binding JWT: {e}"))?;
+
+    // Ensure the KB-JWT binds to this transaction.
+    if kb.nonce.0 != expected_nonce {
+        return Err("KB-JWT nonce does not match the request".into());
+    }
+    if kb.aud != expected_aud {
+        return Err("KB-JWT aud does not match the client_id".into());
+    }
+
+    // Verify the `sd_hash` against the presented SD-JWT using ssi (hashes the
+    // SD-JWT up to and including the last '~' before the KB-JWT).
+    if !kb.sd_hash.verify(SdAlg::Sha256, sd_jwt) {
+        return Err("KB-JWT sd_hash does not match the presented SD-JWT".into());
+    }
+
+    // The KB-JWT must be fresh: `iat` cannot be in the future (beyond clock
+    // skew) nor too far in the past. The window is intentionally generous; tune
+    // it if the conformance suite uses a smaller offset.
+    const CLOCK_SKEW_SECS: f64 = 60.0;
+    const MAX_AGE_SECS: f64 = 300.0;
+    let iat = kb.iat.0.as_seconds();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("system clock error: {e}"))?
+        .as_secs() as f64;
+    if iat > now + CLOCK_SKEW_SECS {
+        return Err("KB-JWT iat is in the future".into());
+    }
+    if iat < now - MAX_AGE_SECS {
+        return Err("KB-JWT iat is too far in the past".into());
+    }
+
+    Ok(())
+}
+
+/// Build a P-256 JWK from the leaf certificate of a JWS `x5c` header.
+fn issuer_key_from_x5c(x5c: &Option<Vec<String>>) -> Result<JWK, String> {
+    let leaf_b64 = x5c
+        .as_ref()
+        .and_then(|chain| chain.first())
+        .ok_or("issuer JWT header has no x5c certificate")?;
+    let der = BASE64_STANDARD
+        .decode(leaf_b64)
+        .map_err(|e| format!("invalid base64 in x5c: {e}"))?;
+    let cert =
+        Certificate::from_der(&der).map_err(|e| format!("invalid x5c certificate DER: {e}"))?;
+
+    // For an EC key the SPKI subject public key is the SEC1 uncompressed point:
+    // 0x04 || X(32) || Y(32).
+    let point = cert
+        .tbs_certificate
+        .subject_public_key_info
+        .subject_public_key
+        .raw_bytes();
+    if point.len() != 65 || point[0] != 0x04 {
+        return Err("unsupported issuer key (expected uncompressed P-256 point)".into());
+    }
+
+    let jwk = serde_json::json!({
+        "kty": "EC",
+        "crv": "P-256",
+        "x": BASE64_URL_SAFE_NO_PAD.encode(&point[1..33]),
+        "y": BASE64_URL_SAFE_NO_PAD.encode(&point[33..65]),
+    });
+    serde_json::from_value(jwk).map_err(|e| format!("failed to build issuer JWK: {e}"))
 }
 
 /// GET /status/:session_id

--- a/examples/verifier-conformance-adapter/server/state.rs
+++ b/examples/verifier-conformance-adapter/server/state.rs
@@ -13,7 +13,7 @@ use openid4vp::{
         dcql_query::{DcqlCredentialQuery, DcqlQuery},
         metadata::{
             parameters::{
-                verifier::JWKs,
+                verifier::{EncryptedResponseEncValuesSupported, JWKs},
                 wallet::{AuthorizationEndpoint, ClientIdPrefixesSupported, VpFormatsSupported},
             },
             WalletMetadata,
@@ -22,7 +22,7 @@ use openid4vp::{
     },
     utils::NonEmptyVec,
     verifier::{
-        client::{Client, X509SanDnsClient},
+        client::{Client, X509HashClient, X509SanDnsClient},
         request_signer::P256Signer,
         session::MemoryStore,
         Verifier,
@@ -47,6 +47,10 @@ pub struct OidfConfig {
     pub d: String,
     pub x5c: String,
     pub client_id: String,
+    /// PEM of the root CA that signed the leaf. Paste this into the conformance
+    /// suite's "Request Object Trust Anchor" field so it can validate the x5c
+    /// chain of the signed request object.
+    pub trust_anchor_pem: String,
 }
 
 pub struct AppState {
@@ -61,14 +65,21 @@ pub struct AppState {
 struct CachedCredentials {
     /// Domain this certificate was generated for
     domain: String,
-    /// DER-encoded certificate (base64)
+    /// DER-encoded leaf certificate (base64)
     cert_der_b64: String,
-    /// PKCS#8 private key (base64)
+    /// DER-encoded root CA certificate (base64). Not sent in x5c, but used as
+    /// the trust anchor for the request object's certificate chain.
+    ca_cert_der_b64: String,
+    /// PKCS#8 private key of the leaf (base64)
     key_pkcs8_b64: String,
 }
 
 impl AppState {
-    pub async fn new(public_url: Url, use_encrypted_response: bool) -> Result<Self> {
+    pub async fn new(
+        public_url: Url,
+        use_encrypted_response: bool,
+        client_id_prefix: &str,
+    ) -> Result<Self> {
         let wallet_authorization_endpoint: Url = WALLET_AUTHORIZATION_ENDPOINT.parse()?;
 
         let domain = public_url
@@ -78,15 +89,23 @@ impl AppState {
 
         info!("Initializing verifier for domain: {}", domain);
 
-        let (signing_key, cert, cert_der) = get_or_generate_cert(&domain)?;
+        let (signing_key, cert, cert_der, ca_der) = get_or_generate_cert(&domain)?;
 
-        let oidf_config = build_oidf_config(&signing_key, &cert_der, &domain);
+        let oidf_config = build_oidf_config(&signing_key, &cert_der, &ca_der, &domain);
 
         let signer = Arc::new(P256Signer::new(signing_key)?);
 
-        let client = Arc::new(X509SanDnsClient::new(vec![cert], signer)?);
+        let client: Arc<dyn Client + Send + Sync> = match client_id_prefix {
+            "x509_hash" => Arc::new(X509HashClient::new(vec![cert], signer)?),
+            "x509_san_dns" => Arc::new(X509SanDnsClient::new(vec![cert], signer)?),
+            other => anyhow::bail!("unsupported client_id_prefix: {other}"),
+        };
 
-        info!("Created X509SanDnsClient with client_id: {}", client.id().0);
+        info!(
+            "Created client ({}) with client_id: {}",
+            client_id_prefix,
+            client.id().0
+        );
 
         let session_store = Arc::new(MemoryStore::default());
 
@@ -118,6 +137,8 @@ impl AppState {
             .with_default_request_parameter(ResponseType::VpToken)
             .with_default_request_parameter(response_mode)
             .with_default_request_parameter(client_metadata)
+            // The request object `aud` (OID4VP §5.8) is defaulted by the library
+            // to "https://self-issued.me/v2" for static Wallet metadata.
             .build()
             .await?;
 
@@ -152,8 +173,8 @@ impl AppState {
     }
 }
 
-/// Get cached certificate or generate a new one for the given domain
-fn get_or_generate_cert(domain: &str) -> Result<(SigningKey, Certificate, Vec<u8>)> {
+/// Get cached certificate material or generate new material for the given domain.
+fn get_or_generate_cert(domain: &str) -> Result<(SigningKey, Certificate, Vec<u8>, Vec<u8>)> {
     let cache_dir = PathBuf::from(CACHE_DIR);
     let cache_file = cache_dir.join(format!("{}.json", domain.replace('.', "_")));
 
@@ -168,25 +189,26 @@ fn get_or_generate_cert(domain: &str) -> Result<(SigningKey, Certificate, Vec<u8
 
     // Generate new certificate
     info!("Generating new certificate for domain: {}", domain);
-    let (signing_key, cert, key_pkcs8) = generate_cert(domain)?;
+    let (signing_key, cert, ca_cert, key_pkcs8) = generate_cert(domain)?;
 
     // Get cert DER for return
     use x509_cert::der::Encode;
     let cert_der = cert.to_der()?;
+    let ca_der = ca_cert.to_der()?;
 
     // Cache it
-    if let Err(e) = save_cert_to_cache(&cache_file, domain, &cert, &key_pkcs8) {
+    if let Err(e) = save_cert_to_cache(&cache_file, domain, &cert, &ca_cert, &key_pkcs8) {
         tracing::warn!("Failed to cache certificate: {}", e);
     }
 
-    Ok((signing_key, cert, cert_der))
+    Ok((signing_key, cert, cert_der, ca_der))
 }
 
-/// Load certificate from cache file
+/// Load certificate material from cache file
 fn load_cached_cert(
     cache_file: &PathBuf,
     expected_domain: &str,
-) -> Result<(SigningKey, Certificate, Vec<u8>)> {
+) -> Result<(SigningKey, Certificate, Vec<u8>, Vec<u8>)> {
     let content = fs::read_to_string(cache_file)?;
     let cached: CachedCredentials = serde_json::from_str(&content)?;
 
@@ -202,14 +224,17 @@ fn load_cached_cert(
     let cert_der = BASE64_STANDARD.decode(&cached.cert_der_b64)?;
     let cert = Certificate::from_der(&cert_der)?;
 
+    let ca_der = BASE64_STANDARD.decode(&cached.ca_cert_der_b64)?;
+
     info!("Successfully loaded cached certificate");
-    Ok((signing_key, cert, cert_der))
+    Ok((signing_key, cert, cert_der, ca_der))
 }
 
 fn save_cert_to_cache(
     cache_file: &PathBuf,
     domain: &str,
     cert: &Certificate,
+    ca_cert: &Certificate,
     key_pkcs8: &[u8],
 ) -> Result<()> {
     use base64::prelude::*;
@@ -222,6 +247,7 @@ fn save_cert_to_cache(
     let cached = CachedCredentials {
         domain: domain.to_string(),
         cert_der_b64: BASE64_STANDARD.encode(cert.to_der()?),
+        ca_cert_der_b64: BASE64_STANDARD.encode(ca_cert.to_der()?),
         key_pkcs8_b64: BASE64_STANDARD.encode(key_pkcs8),
     };
 
@@ -232,42 +258,89 @@ fn save_cert_to_cache(
     Ok(())
 }
 
-fn generate_cert(domain: &str) -> Result<(SigningKey, Certificate, Vec<u8>)> {
+/// Generate a leaf certificate and its issuing CA for the given domain.
+///
+/// Returns the leaf signing key, the leaf certificate, the CA certificate, and
+/// the leaf's PKCS#8 private key.
+fn generate_cert(domain: &str) -> Result<(SigningKey, Certificate, Certificate, Vec<u8>)> {
     use p256::pkcs8::DecodePrivateKey;
+    use rcgen::{BasicConstraints, IsCa};
 
-    let key_pair = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)
-        .context("Failed to generate key pair")?;
+    // 1. Self-signed CA used only to sign the leaf (acts as the trust anchor).
+    let ca_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)
+        .context("Failed to generate CA key pair")?;
 
-    let mut params = CertificateParams::default();
-    params
+    let mut ca_params = CertificateParams::default();
+    ca_params
         .distinguished_name
-        .push(DnType::CommonName, "OID4VP Verifier");
-    params
+        .push(DnType::CommonName, "OID4VP Conformance Test CA");
+    ca_params
         .distinguished_name
         .push(DnType::OrganizationName, "Conformance Test");
-    params.distinguished_name.push(DnType::CountryName, "BR");
+    ca_params.distinguished_name.push(DnType::CountryName, "BR");
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
 
-    params.subject_alt_names = vec![SanType::DnsName(domain.to_string().try_into()?)];
+    let ca_cert_rcgen = ca_params
+        .self_signed(&ca_key)
+        .context("Failed to generate CA certificate")?;
 
-    let cert_rcgen = params
-        .self_signed(&key_pair)
-        .context("Failed to generate self-signed certificate")?;
+    // 2. Leaf certificate signed by the CA (not self-signed).
+    let leaf_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)
+        .context("Failed to generate leaf key pair")?;
 
-    let cert_der = cert_rcgen.der().to_vec();
+    let mut leaf_params = CertificateParams::default();
+    leaf_params
+        .distinguished_name
+        .push(DnType::CommonName, "OID4VP Verifier");
+    leaf_params
+        .distinguished_name
+        .push(DnType::OrganizationName, "Conformance Test");
+    leaf_params
+        .distinguished_name
+        .push(DnType::CountryName, "BR");
+    leaf_params.subject_alt_names = vec![SanType::DnsName(domain.to_string().try_into()?)];
 
-    let cert = Certificate::from_der(&cert_der).context("Failed to parse generated certificate")?;
+    let leaf_cert_rcgen = leaf_params
+        .signed_by(&leaf_key, &ca_cert_rcgen, &ca_key)
+        .context("Failed to generate leaf certificate")?;
 
-    let key_pkcs8 = key_pair.serialize_der();
+    let leaf_der = leaf_cert_rcgen.der().to_vec();
+    let ca_der = ca_cert_rcgen.der().to_vec();
+
+    let leaf_cert =
+        Certificate::from_der(&leaf_der).context("Failed to parse generated leaf certificate")?;
+    let ca_cert =
+        Certificate::from_der(&ca_der).context("Failed to parse generated CA certificate")?;
+
+    let key_pkcs8 = leaf_key.serialize_der();
 
     let signing_key = SigningKey::from_pkcs8_der(&key_pkcs8)
-        .context("Failed to create signing key from generated key")?;
+        .context("Failed to create signing key from leaf key")?;
 
-    info!("Generated self-signed certificate for domain: {}", domain);
+    info!(
+        "Generated CA-signed leaf certificate for domain: {}",
+        domain
+    );
 
-    Ok((signing_key, cert, key_pkcs8))
+    Ok((signing_key, leaf_cert, ca_cert, key_pkcs8))
 }
 
-fn build_oidf_config(signing_key: &SigningKey, cert_der: &[u8], domain: &str) -> OidfConfig {
+fn der_to_pem(der: &[u8]) -> String {
+    let b64 = BASE64_STANDARD.encode(der);
+    let mut body = String::new();
+    for chunk in b64.as_bytes().chunks(64) {
+        body.push_str(std::str::from_utf8(chunk).unwrap());
+        body.push('\n');
+    }
+    format!("-----BEGIN CERTIFICATE-----\n{body}-----END CERTIFICATE-----\n")
+}
+
+fn build_oidf_config(
+    signing_key: &SigningKey,
+    cert_der: &[u8],
+    ca_der: &[u8],
+    domain: &str,
+) -> OidfConfig {
     let point = signing_key.verifying_key().to_encoded_point(false);
 
     OidfConfig {
@@ -276,6 +349,7 @@ fn build_oidf_config(signing_key: &SigningKey, cert_der: &[u8], domain: &str) ->
         d: BASE64_URL_SAFE_NO_PAD.encode(signing_key.to_bytes()),
         x5c: BASE64_STANDARD.encode(cert_der),
         client_id: domain.to_string(),
+        trust_anchor_pem: der_to_pem(ca_der),
     }
 }
 
@@ -327,6 +401,13 @@ fn build_client_metadata(
             keys: vec![public_jwk.clone()],
         };
         inner.insert(jwks);
+
+        // HAIP Section 5: Verifiers MUST list both A128GCM and A256GCM in
+        // `encrypted_response_enc_values_supported`.
+        inner.insert(EncryptedResponseEncValuesSupported(vec![
+            "A128GCM".to_string(),
+            "A256GCM".to_string(),
+        ]));
     }
 
     ClientMetadata(inner)
@@ -345,9 +426,10 @@ fn create_wallet_metadata(authorization_endpoint: Url) -> Result<WalletMetadata>
         None,
     );
 
-    metadata.insert(ClientIdPrefixesSupported(vec![ClientIdScheme(
-        ClientIdScheme::X509_SAN_DNS.to_string(),
-    )]));
+    metadata.insert(ClientIdPrefixesSupported(vec![
+        ClientIdScheme(ClientIdScheme::X509_SAN_DNS.to_string()),
+        ClientIdScheme(ClientIdScheme::X509_HASH.to_string()),
+    ]));
 
     Ok(metadata)
 }

--- a/examples/wallet-conformance-adapter/README.md
+++ b/examples/wallet-conformance-adapter/README.md
@@ -35,13 +35,14 @@ Go to https://demo.certification.openid.net/ and create a new test plan.
 
 ### Test Configuration
 
-| Field | Value |
-|-------|-------|
-| **Test Plan** | `OpenID for Verifiable Presentations 1.0 Final: Test a wallet` |
-| **Credential Format** | `sd_jwt_vc` |
-| **Client Id Prefix** | `redirect_uri` |
-| **Request Method** | `request_uri_unsigned` |
-| **Response Mode** | `direct_post` or `direct_post.jwt` |
+| Field                 | Value                                                          |
+| --------------------- | -------------------------------------------------------------- |
+| **Test Plan**         | `OpenID for Verifiable Presentations 1.0 Final: Test a wallet` |
+| **Credential Format** | `sd_jwt_vc`                                                    |
+| **Client Id Prefix**  | `redirect_uri` (base) or `x509_hash` (HAIP)                    |
+| **Request Method**    | `request_uri_unsigned` (base) or `request_uri_signed` (HAIP)   |
+| **Response Mode**     | `direct_post` or `direct_post.jwt`                             |
+| **VP Profile**        | `plain_vp` (base) or `haip`                                    |
 
 ### Sample Configuration
 
@@ -50,7 +51,7 @@ Go to https://demo.certification.openid.net/ and create a new test plan.
   "alias": "my-wallet-oid4vp1",
   "description": "OID4VP 1.0 Final wallet conformance - headless SD-JWT VC, redirect_uri, request_uri_unsigned, direct_post",
   "server": {
-    "authorization_endpoint": "YOUR_NGROK_URL.ngrok-free.app/authorize"
+    "authorization_endpoint": "https://YOUR_NGROK_URL.ngrok-free.app/authorize"
   },
   "client": {
     "client_id_prefix": "redirect_uri",
@@ -65,7 +66,13 @@ Go to https://demo.certification.openid.net/ and create a new test plan.
           "format": "dc+sd-jwt",
           "meta": {
             "vct_values": ["https://credentials.example.com/pid/1.0"]
-          }
+          },
+          "claims": [
+            { "path": ["given_name"] },
+            { "path": ["family_name"] },
+            { "path": ["nationality"] },
+            { "path": ["age_over_18"] }
+          ]
         }
       ]
     },
@@ -87,24 +94,89 @@ Go to https://demo.certification.openid.net/ and create a new test plan.
 }
 ```
 
+### HAIP profile configuration
+
+For the `haip` VP profile the variant is `x509_hash` / `request_uri_signed` / `direct_post.jwt`. In a wallet test the conformance suite acts as the **verifier** and signs the request object, so the `client.jwks` signing key MUST carry an `x5c` certificate chain (HAIP Section 5 also requires the leaf to be CA-signed, i.e. not self-signed). The default sample key above has no `x5c`, which fails with `SetClientIdToX509Hash: ... the signing key in the client jwks ... doesn't have an x5c entry`.
+
+Use this config instead (the key below is a CA-signed leaf; the CA is given afterwards as the wallet's trust anchor):
+
+```json
+{
+  "alias": "my-wallet-oid4vp1",
+  "description": "OID4VP 1.0 Final wallet conformance - HAIP SD-JWT VC, x509_hash, request_uri_signed, direct_post.jwt",
+  "server": {
+    "authorization_endpoint": "https://YOUR_NGROK_URL.ngrok-free.app/authorize"
+  },
+  "client": {
+    "client_id_prefix": "x509_hash",
+    "request_method": "request_uri_signed",
+    "response_mode": "direct_post.jwt",
+    "authorization_encrypted_response_alg": "ECDH-ES",
+    "authorization_encrypted_response_enc": "A256GCM",
+    "dcql": {
+      "credentials": [
+        {
+          "id": "cred1",
+          "format": "dc+sd-jwt",
+          "meta": {
+            "vct_values": ["https://credentials.example.com/pid/1.0"]
+          },
+          "claims": [
+            { "path": ["given_name"] },
+            { "path": ["family_name"] },
+            { "path": ["nationality"] },
+            { "path": ["age_over_18"] }
+          ]
+        }
+      ]
+    },
+    "jwks": {
+      "keys": [
+        {
+          "kty": "EC",
+          "crv": "P-256",
+          "d": "O3oF9vyix0iQsXDGAsHLgfM55I7HqPIL6Y9xkLJJsHU",
+          "x": "k85V0J-TvX4gmMT_C-hOgqZNR3jnk4bNr1aBfmR8vqw",
+          "y": "pb0HQW7d08BnJOrjbX92A63ZFksl0_4Yj5oBLtz41rc",
+          "kid": "conformance-test-key",
+          "use": "sig",
+          "alg": "ES256",
+          "x5c": [
+            "MIIB1jCCAXugAwIBAgIUVjuNa1Q/Su/k4mVVls7wowAhbyEwCgYIKoZIzj0EAwIwTTELMAkGA1UEBhMCQlIxGTAXBgNVBAoMEENvbmZvcm1hbmNlIFRlc3QxIzAhBgNVBAMMGk9JRDRWUCBDb25mb3JtYW5jZSBUZXN0IENBMCAXDTI2MDUyOTE5NTEwOFoYDzIxMjYwNTA1MTk1MTA4WjBCMQswCQYDVQQGEwJCUjEZMBcGA1UECgwQQ29uZm9ybWFuY2UgVGVzdDEYMBYGA1UEAwwPT0lENFZQIFZlcmlmaWVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEk85V0J+TvX4gmMT/C+hOgqZNR3jnk4bNr1aBfmR8vqylvQdBbt3TwGck6uNtf3YDrdkWSyXT/hiPmgEu3PjWt6NCMEAwHQYDVR0OBBYEFL0dHtuSYzXnrFxJA9CGFgJ4yoODMB8GA1UdIwQYMBaAFNnEtUYZ0L6IyEYuLNUz9hf9PCqfMAoGCCqGSM49BAMCA0kAMEYCIQDhdP2g9bw8ySHU3/HS0ls4CnM2WZgdVrMn+kUHmuYCrgIhAKhrIfV/Ag84vlgy30pqlqSs36DWRulHRHCRkKX4ry9+"
+          ]
+        }
+      ]
+    }
+  },
+  "credential": {
+    "trust_anchor_pem": "-----BEGIN CERTIFICATE-----\nMIIBxzCCAWygAwIBAgIUEAJqpjLRGxVMcRN2IgsiqpVlNokwCgYIKoZIzj0EAwIw\nSDEeMBwGA1UEAwwVT0lENFZQIElzc3VlciBUZXN0IENBMRkwFwYDVQQKDBBDb25m\nb3JtYW5jZSBUZXN0MQswCQYDVQQGDAJCUjAgFw03NTAxMDEwMDAwMDBaGA80MDk2\nMDEwMTAwMDAwMFowSDEeMBwGA1UEAwwVT0lENFZQIElzc3VlciBUZXN0IENBMRkw\nFwYDVQQKDBBDb25mb3JtYW5jZSBUZXN0MQswCQYDVQQGDAJCUjBZMBMGByqGSM49\nAgEGCCqGSM49AwEHA0IABPGp7fgd/ysv1nen+8mb3nh0fyazE3BD2ixN1ccv15Yz\ngSmef7QRQZlqX+nDVoUl08vbadeae4m8R7XviEewnBSjMjAwMB0GA1UdDgQWBBTh\nGZAX0q9N8UdcjeUgtG2Z85JwGzAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMC\nA0kAMEYCIQDfhmQQjf6xWIm2nxsOY0PoA23wL1Fqc9q9mITpCSjQBgIhAJ1O7CWM\nGjhfItLbkm/vTpZxeGjAKqQ7xbV8vqa2VGaK\n-----END CERTIFICATE-----",
+    "status_list_trust_anchor_pem": "-----BEGIN CERTIFICATE-----\nMIIBxzCCAWygAwIBAgIUEAJqpjLRGxVMcRN2IgsiqpVlNokwCgYIKoZIzj0EAwIw\nSDEeMBwGA1UEAwwVT0lENFZQIElzc3VlciBUZXN0IENBMRkwFwYDVQQKDBBDb25m\nb3JtYW5jZSBUZXN0MQswCQYDVQQGDAJCUjAgFw03NTAxMDEwMDAwMDBaGA80MDk2\nMDEwMTAwMDAwMFowSDEeMBwGA1UEAwwVT0lENFZQIElzc3VlciBUZXN0IENBMRkw\nFwYDVQQKDBBDb25mb3JtYW5jZSBUZXN0MQswCQYDVQQGDAJCUjBZMBMGByqGSM49\nAgEGCCqGSM49AwEHA0IABPGp7fgd/ysv1nen+8mb3nh0fyazE3BD2ixN1ccv15Yz\ngSmef7QRQZlqX+nDVoUl08vbadeae4m8R7XviEewnBSjMjAwMB0GA1UdDgQWBBTh\nGZAX0q9N8UdcjeUgtG2Z85JwGzAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMC\nA0kAMEYCIQDfhmQQjf6xWIm2nxsOY0PoA23wL1Fqc9q9mITpCSjQBgIhAJ1O7CWM\nGjhfItLbkm/vTpZxeGjAKqQ7xbV8vqa2VGaK\n-----END CERTIFICATE-----"
+  }
+}
+```
+
+The `credential` block is a top-level key (sibling of `server` and `client`), placed last before the closing brace. Both PEMs are JSON strings, so the newlines are escaped as `\n`.
+
+> **Note:** `trust_anchor_pem` is the **issuer CA** — the suite uses it to verify the SD-JWT VC the wallet presents. The wallet adapter uses a fixed (hardcoded) issuer key/CA, so the PEM above is the real value and works as-is (it is also printed on startup). The same CA is reused for `status_list_trust_anchor_pem`. The `x5c` inside `client.jwks` is unrelated — that is the _verifier's_ request-signing certificate, used by the suite to sign the request object.
+
 ### Running Tests
 
 After starting a test, open the authorization URL in Firefox (not Chrome - it may send duplicate requests causing failures).
 
 ## Endpoints
 
-| Endpoint | Description |
-|----------|-------------|
-| `GET/POST /authorize` | Authorization endpoint |
-| `GET /.well-known/openid-configuration` | Wallet metadata |
-| `GET /.well-known/jwks.json` | Public keys (JWKS) |
-| `GET /health` | Health check |
-| `GET /debug/credentials` | List mock credentials |
+| Endpoint                                | Description            |
+| --------------------------------------- | ---------------------- |
+| `GET/POST /authorize`                   | Authorization endpoint |
+| `GET /.well-known/openid-configuration` | Wallet metadata        |
+| `GET /.well-known/jwks.json`            | Public keys (JWKS)     |
+| `GET /health`                           | Health check           |
+| `GET /debug/credentials`                | List mock credentials  |
 
 ## Mock Credentials
 
-| Credential | Format | VCT |
-|------------|--------|-----|
+| Credential     | Format      | VCT                                       |
+| -------------- | ----------- | ----------------------------------------- |
 | PID Credential | `dc+sd-jwt` | `https://credentials.example.com/pid/1.0` |
 
 ## Development

--- a/examples/wallet-conformance-adapter/crypto/issuer.rs
+++ b/examples/wallet-conformance-adapter/crypto/issuer.rs
@@ -1,0 +1,58 @@
+//! Issuer key + certificate and SD-JWT VC (re)issuance for HAIP conformance.
+//!
+//! HAIP Section 6.1.1 requires the SD-JWT VC issuer signature to be validated
+//! via X.509: the issuer JWT MUST carry `typ: dc+sd-jwt` and an `x5c` chain
+//! (leaf signed by a CA, not self-signed; trust anchor excluded from `x5c`).
+//!
+//! The issuer key and leaf certificate are hardcoded test fixtures (like the
+//! holder key in `keys.rs`), so they are identical on every run and machine. The
+//! issuing CA (credential trust anchor) PEM is published in the adapter README
+//! for the conformance suite's "Credential Trust Anchor" field.
+
+use anyhow::Result;
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+use base64::Engine;
+use p256::ecdsa::{signature::Signer, Signature, SigningKey};
+use p256::pkcs8::DecodePrivateKey;
+use serde_json::{json, Value};
+use std::sync::LazyLock;
+
+/// PKCS#8 private key of the issuer leaf (base64).
+const ISSUER_KEY_PKCS8_B64: &str = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgucnzHrLxzgG5AfzfyEngt9lHZjGiGA7eyq5tl7vdk06hRANCAATLJMxI8pODFtGRGpVe/TeeJgD7PHFkcTfKmfkwHggFB7zhMWVFRzD/TLRNZfdjsdIx0w30646Saac2ASYMFXWF";
+
+/// DER-encoded issuer leaf certificate (base64) — goes in the `x5c` header.
+const ISSUER_LEAF_DER_B64: &str = "MIIBijCCATCgAwIBAgIUJ0PCKRnkSmbwl+FPi49lSjIlOQQwCgYIKoZIzj0EAwIwSDEeMBwGA1UEAwwVT0lENFZQIElzc3VlciBUZXN0IENBMRkwFwYDVQQKDBBDb25mb3JtYW5jZSBUZXN0MQswCQYDVQQGDAJCUjAgFw03NTAxMDEwMDAwMDBaGA80MDk2MDEwMTAwMDAwMFowQDEWMBQGA1UEAwwNT0lENFZQIElzc3VlcjEZMBcGA1UECgwQQ29uZm9ybWFuY2UgVGVzdDELMAkGA1UEBgwCQlIwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATLJMxI8pODFtGRGpVe/TeeJgD7PHFkcTfKmfkwHggFB7zhMWVFRzD/TLRNZfdjsdIx0w30646Saac2ASYMFXWFMAoGCCqGSM49BAMCA0gAMEUCIEaIH3C/LCVDUhPZrVjbBnSQhLCoPVlCPQQXRgBgaBjYAiEApcOXzuZeL1j5Ma/nHuI8HG13lOPu/IYOoafbw1k4qxM=";
+
+struct IssuerMaterial {
+    signing_key: SigningKey,
+    leaf_der: Vec<u8>,
+}
+
+static ISSUER: LazyLock<IssuerMaterial> = LazyLock::new(|| {
+    let key_pkcs8 = STANDARD
+        .decode(ISSUER_KEY_PKCS8_B64)
+        .expect("invalid issuer key base64");
+    let signing_key = SigningKey::from_pkcs8_der(&key_pkcs8).expect("invalid issuer signing key");
+
+    IssuerMaterial {
+        signing_key,
+        leaf_der: STANDARD
+            .decode(ISSUER_LEAF_DER_B64)
+            .expect("invalid issuer leaf base64"),
+    }
+});
+
+/// Sign an issuer-signed SD-JWT VC JWT (`typ: dc+sd-jwt`, `x5c: [leaf]`).
+pub fn sign_issuer_jwt(payload: &Value) -> Result<String> {
+    let header = json!({
+        "alg": "ES256",
+        "typ": "dc+sd-jwt",
+        "x5c": [STANDARD.encode(&ISSUER.leaf_der)],
+    });
+    let header_b64 = URL_SAFE_NO_PAD.encode(header.to_string().as_bytes());
+    let payload_b64 = URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+    let signing_input = format!("{header_b64}.{payload_b64}");
+    let signature: Signature = ISSUER.signing_key.sign(signing_input.as_bytes());
+    let signature_b64 = URL_SAFE_NO_PAD.encode(signature.to_bytes());
+    Ok(format!("{signing_input}.{signature_b64}"))
+}

--- a/examples/wallet-conformance-adapter/crypto/mod.rs
+++ b/examples/wallet-conformance-adapter/crypto/mod.rs
@@ -1,3 +1,5 @@
+mod issuer;
 mod keys;
 
+pub use issuer::sign_issuer_jwt;
 pub use keys::{create_key_binding_jwt, public_jwk};

--- a/examples/wallet-conformance-adapter/dcql/matcher.rs
+++ b/examples/wallet-conformance-adapter/dcql/matcher.rs
@@ -1,7 +1,11 @@
 use crate::credentials::{CredentialStore, MockCredential};
+use crate::crypto::sign_issuer_jwt;
 use crate::engine::{CredentialSelection, EngineError};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
 use openid4vp::core::dcql_query::{DcqlCredentialClaimsQueryPath, DcqlCredentialQuery, DcqlQuery};
-use tracing::{debug, warn};
+use sha2::{Digest, Sha256};
+use tracing::debug;
 
 /// DCQL credential matcher
 pub struct DcqlMatcher<'a> {
@@ -20,33 +24,52 @@ impl<'a> DcqlMatcher<'a> {
     /// credential query in the DCQL.
     pub fn match_query(&self, query: &DcqlQuery) -> Result<CredentialSelection, EngineError> {
         let mut selection = CredentialSelection::new();
+        let mut unmatched: Vec<String> = Vec::new();
 
+        // Try to satisfy each credential query, but don't fail hard yet: a query
+        // may belong to an optional `credential_sets` option, in which case it is
+        // fine for it to go unmatched (OID4VP §6.1 DCQL credential_sets).
         for cred_query in query.credentials() {
             let cred_id = cred_query.id();
             debug!(cred_id, format = ?cred_query.format(), "Matching credential query");
 
-            let matched = self.match_credential_query(cred_query)?;
-
-            selection.add(cred_id, matched.raw_credential.clone());
+            match self.match_credential_query(cred_query) {
+                Ok(matched) => {
+                    let requested = self.extract_required_claims(cred_query);
+                    let presentation = reissue_sd_jwt(matched, &requested)?;
+                    selection.add(cred_id, presentation);
+                }
+                Err(e) => {
+                    debug!(cred_id, "credential query did not match: {e}");
+                    unmatched.push(cred_id.to_string());
+                }
+            }
         }
 
-        // Handle credential_sets if present (alternative selection logic)
         if let Some(cred_sets) = query.credential_sets() {
-            debug!("DCQL has credential_sets - checking requirements");
-            // For now, we just ensure at least one option is satisfied
-            // A full implementation would check all required sets
+            // With credential_sets, every *required* set must have at least one
+            // fully-matched option; unmatched credentials in optional sets are ok.
             for cred_set in cred_sets.iter() {
+                if !cred_set.is_required() {
+                    continue;
+                }
                 let satisfied = cred_set.options().iter().any(|option| {
                     option
                         .iter()
                         .all(|cred_id| selection.presentations.contains_key(cred_id))
                 });
-
-                if !satisfied && cred_set.is_required() {
-                    warn!("Required credential set not satisfied");
-                    // Continue anyway for conformance testing
+                if !satisfied {
+                    return Err(EngineError::NoMatchingCredential(
+                        "no matchable option for a required credential_set".to_string(),
+                    ));
                 }
             }
+        } else if !unmatched.is_empty() {
+            // Without credential_sets, every credential query is required.
+            return Err(EngineError::NoMatchingCredential(format!(
+                "no credential found for required query/queries: {}",
+                unmatched.join(", ")
+            )));
         }
 
         if selection.is_empty() {
@@ -138,4 +161,83 @@ impl<'a> DcqlMatcher<'a> {
 
         claims
     }
+}
+
+/// Re-issue a stored SD-JWT VC with a real issuer signature (HAIP `dc+sd-jwt`
+/// header + `x5c`) and disclose only the requested claims.
+///
+/// The stored `raw_credential` provides the issuer claims (`iss`, `vct`, `cnf`,
+/// `iat`, `exp`) and the disclosures; we recompute the `_sd` digests, sign a
+/// fresh issuer JWT, and append only the disclosures whose claim name appears in
+/// `requested` (none when no claims are requested, per OID4VP §6.4.1). The
+/// returned string ends with `~` and carries no KB-JWT (added later).
+fn reissue_sd_jwt(cred: &MockCredential, requested: &[String]) -> Result<String, EngineError> {
+    let parts: Vec<&str> = cred.raw_credential.split('~').collect();
+    let issuer_jwt = parts.first().copied().unwrap_or_default();
+
+    // Disclosures are dot-free base64url segments; the issuer JWT and the mock
+    // KB-JWT both contain '.', so filtering on '.' drops them.
+    let disclosures: Vec<&str> = parts[1..]
+        .iter()
+        .copied()
+        .filter(|p| !p.is_empty() && !p.contains('.'))
+        .collect();
+
+    // Decode the original issuer JWT payload to reuse its claims.
+    let payload_b64 = issuer_jwt.split('.').nth(1).ok_or_else(|| {
+        EngineError::Internal("stored credential issuer JWT is malformed".to_string())
+    })?;
+    let payload_bytes = URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .map_err(|e| EngineError::Internal(format!("issuer JWT payload base64: {e}")))?;
+    let original: serde_json::Value = serde_json::from_slice(&payload_bytes)
+        .map_err(|e| EngineError::Internal(format!("issuer JWT payload JSON: {e}")))?;
+
+    // Compute the _sd digest of every disclosure and map digests to claim names.
+    let mut sd_digests = Vec::new();
+    let mut name_by_disclosure: Vec<(String, &str)> = Vec::new();
+    for d in &disclosures {
+        let digest = URL_SAFE_NO_PAD.encode(Sha256::digest(d.as_bytes()));
+        sd_digests.push(serde_json::Value::String(digest));
+
+        let decoded = URL_SAFE_NO_PAD
+            .decode(d)
+            .map_err(|e| EngineError::Internal(format!("disclosure base64: {e}")))?;
+        let arr: serde_json::Value = serde_json::from_slice(&decoded)
+            .map_err(|e| EngineError::Internal(format!("disclosure JSON: {e}")))?;
+        // Disclosure format: [salt, claim_name, value]
+        let name = arr
+            .get(1)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        name_by_disclosure.push((name, d));
+    }
+
+    // Build the fresh issuer payload, committing to all disclosures via `_sd`.
+    let mut payload = serde_json::Map::new();
+    for key in ["iss", "vct", "cnf", "iat", "exp", "sub"] {
+        if let Some(v) = original.get(key) {
+            payload.insert(key.to_string(), v.clone());
+        }
+    }
+    payload.insert("_sd".to_string(), serde_json::Value::Array(sd_digests));
+    payload.insert(
+        "_sd_alg".to_string(),
+        serde_json::Value::String("sha-256".to_string()),
+    );
+
+    let new_issuer_jwt = sign_issuer_jwt(&serde_json::Value::Object(payload))
+        .map_err(|e| EngineError::CryptoError(e.to_string()))?;
+
+    // Disclose only the requested claims (none when `requested` is empty).
+    let mut out = new_issuer_jwt;
+    for (name, disclosure) in &name_by_disclosure {
+        if requested.iter().any(|r| r == name) {
+            out.push('~');
+            out.push_str(disclosure);
+        }
+    }
+    out.push('~');
+    Ok(out)
 }

--- a/examples/wallet-conformance-adapter/server/handlers/authorization.rs
+++ b/examples/wallet-conformance-adapter/server/handlers/authorization.rs
@@ -1,22 +1,35 @@
+use anyhow::Context as _;
+use async_trait::async_trait;
 use axum::{
     extract::{Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     Form, Json,
 };
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use openid4vp::core::{
     authorization_request::{
-        parameters::{ResponseMode, State as RequestState},
+        parameters::{ClientIdScheme, ResponseMode, State as RequestState, TransactionData},
+        verification::{verifier::P256Verifier, x509_hash, RequestVerifier},
         AuthorizationRequest, AuthorizationRequestObject,
     },
+    credential_format::{ClaimFormatDesignation, ClaimFormatMap, ClaimFormatPayload},
     dcql_query::DcqlQuery,
-    jwe::{find_encryption_jwk, EncryptionJwkInfo, JweBuilder},
-    object::ParsingErrorContext,
-    response::{parameters::VpToken, UnencodedAuthorizationResponse},
+    jwe::build_encrypted_response,
+    metadata::{
+        parameters::wallet::{
+            AuthorizationEncryptionAlgValuesSupported, AuthorizationEncryptionEncValuesSupported,
+            AuthorizationEndpoint, ClientIdPrefixesSupported,
+            RequestObjectSigningAlgValuesSupported, VpFormatsSupported,
+        },
+        WalletMetadata,
+    },
+    response::{parameters::VpToken, AuthorizationResponse, UnencodedAuthorizationResponse},
     util::ReqwestClient,
 };
+use openid4vp::wallet::Wallet;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::Value;
 use tracing::{debug, error, info, instrument, warn};
 
 use crate::server::AppState;
@@ -118,33 +131,45 @@ async fn process_authorization_request(state: AppState, params: AuthorizationPar
             }
         };
 
-    // 3. Resolve the request (fetch request_uri if needed, decode JWT)
-    let http_client = match ReqwestClient::new() {
-        Ok(client) => client,
+    // 3. Resolve and verify the request.
+    let wallet = match ConformanceWallet::new(state.config.authorization_endpoint.clone()) {
+        Ok(w) => w,
         Err(e) => {
-            error!("Failed to create HTTP client: {}", e);
+            error!("Failed to build wallet for verification: {}", e);
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "server_error",
-                &format!("Failed to create HTTP client: {}", e),
+                &format!("Failed to build wallet: {}", e),
                 params.state.as_deref(),
             );
         }
     };
-    let (request_object, _jwt) = match auth_request.resolve_request(&http_client).await {
-        Ok(result) => result,
+    let request_object = match auth_request.validate(&wallet).await {
+        Ok(aro) => aro,
         Err(e) => {
-            error!("Failed to resolve authorization request: {}", e);
+            error!("Authorization request validation failed: {:#}", e);
             return error_response(
                 StatusCode::BAD_REQUEST,
                 "invalid_request",
-                &format!("Failed to resolve request: {}", e),
+                &format!("{e:#}"),
                 params.state.as_deref(),
             );
         }
     };
 
-    debug!("Authorization request resolved successfully");
+    debug!("Authorization request resolved and verified successfully");
+
+    // 3c. Reject requests carrying transaction_data with an unrecognized type
+    // (OID4VP §5.1 / §8.4). This wallet supports no transaction_data types.
+    if let Err(e) = validate_transaction_data(&request_object) {
+        error!("transaction_data validation failed: {}", e);
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_transaction_data",
+            &e,
+            params.state.as_deref(),
+        );
+    }
 
     // 4. Extract DCQL query using the dedicated method
     let dcql_query: DcqlQuery = match request_object.dcql_query() {
@@ -420,57 +445,21 @@ async fn submit_direct_post_jwt(
     vp_token: VpToken,
     original_state: Option<String>,
 ) -> Response {
-    // Build the payload to encrypt
-    let mut payload = json!({
-        "vp_token": vp_token,
-    });
-
-    if let Some(ref state_val) = original_state {
-        payload["state"] = Value::String(state_val.clone());
-    }
-
-    // Get verifier's public key from client_metadata
-    let jwk_info = match get_verifier_encryption_key(request_object) {
-        Ok(info) => info,
-        Err(e) => {
-            error!("Failed to get verifier encryption key: {}", e);
-            return error_response(
-                StatusCode::BAD_REQUEST,
-                "invalid_client_metadata",
-                &format!("Missing encryption key: {}", e),
-                original_state.as_deref(),
-            );
-        }
-    };
-
-    // Convert JWK to JSON Value for the builder
-    let verifier_jwk: Value = match serde_json::to_value(&jwk_info.jwk) {
-        Ok(v) => v,
-        Err(e) => {
-            error!("Failed to serialize JWK: {}", e);
+    // Build the JWE-encrypted response per OID4VP §8.3.
+    let state_param = original_state.as_ref().map(|s| RequestState(s.clone()));
+    let jwe = match build_encrypted_response(request_object, &vp_token, state_param.as_ref()) {
+        Ok(AuthorizationResponse::Jwt(jwt)) => jwt.response,
+        Ok(_) => {
+            error!("encrypted response was unexpectedly not a JWT");
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "encryption_error",
-                &e.to_string(),
+                "unexpected response form",
                 original_state.as_deref(),
             );
         }
-    };
-
-    // Build JWE per OID4VP v1.0 §8.3 (alg from JWK, enc default A128GCM)
-    let mut builder = JweBuilder::new().payload(payload).alg(&jwk_info.alg);
-
-    if let Some(ref kid) = jwk_info.kid {
-        builder = builder.kid(kid);
-    }
-
-    let jwe = match builder
-        .recipient_key_json(&verifier_jwk)
-        .and_then(|b| b.build())
-    {
-        Ok(jwe) => jwe,
         Err(e) => {
-            error!("JWE encryption failed: {}", e);
+            error!("JWE encryption failed: {:#}", e);
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "encryption_error",
@@ -548,15 +537,119 @@ async fn submit_direct_post_jwt(
     }
 }
 
-/// Get verifier's encryption key from client_metadata
-fn get_verifier_encryption_key(
-    request: &AuthorizationRequestObject,
-) -> anyhow::Result<EncryptionJwkInfo> {
-    let client_metadata = request.client_metadata().parsing_error()?;
-    let jwks = client_metadata.jwks().parsing_error()?;
-    let keys: Vec<_> = jwks.keys.iter().collect();
+/// A minimal [`Wallet`]/[`RequestVerifier`] used to validate incoming requests
+/// through the library: the dispatch in `verify_request` rejects unsupported
+/// client_id prefixes (via the wallet metadata and the default `bail!`ing trait
+/// methods) and verifies the request object signature for `x509_hash`.
+struct ConformanceWallet {
+    metadata: WalletMetadata,
+    http_client: ReqwestClient,
+}
 
-    find_encryption_jwk(keys.into_iter())
+impl ConformanceWallet {
+    fn new(authorization_endpoint: url::Url) -> anyhow::Result<Self> {
+        Ok(Self {
+            metadata: build_verification_metadata(authorization_endpoint),
+            http_client: ReqwestClient::new()?,
+        })
+    }
+}
+
+#[async_trait]
+impl RequestVerifier for ConformanceWallet {
+    /// `x509_hash` (HAIP): verify the request object signature against the `x5c`
+    /// leaf and that `client_id == x509_hash:<sha256(leaf)>`.
+    async fn x509_hash(
+        &self,
+        decoded_request: &AuthorizationRequestObject,
+        request_jwt: Option<String>,
+    ) -> anyhow::Result<()> {
+        let jwt = request_jwt.context("x509_hash request object must be a signed JWT")?;
+        x509_hash::validate::<P256Verifier>(self.metadata(), decoded_request, jwt, None)
+    }
+
+    /// `redirect_uri` (unsigned base profile): nothing to verify here; the
+    /// response_uri/client_id match is checked later in the handler.
+    async fn redirect_uri(
+        &self,
+        _decoded_request: &AuthorizationRequestObject,
+        _request_jwt: Option<String>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    // All other prefixes (including unknown ones via `other`) keep the default
+    // implementations, which reject the request.
+}
+
+#[async_trait]
+impl Wallet for ConformanceWallet {
+    type HttpClient = ReqwestClient;
+
+    fn metadata(&self) -> &WalletMetadata {
+        &self.metadata
+    }
+
+    fn http_client(&self) -> &Self::HttpClient {
+        &self.http_client
+    }
+}
+
+/// Build the wallet metadata used to validate incoming requests. It advertises
+/// the prefixes (`x509_hash`, `redirect_uri`) and crypto the conformance plans
+/// use, so the library's metadata check passes for valid requests and rejects
+/// unsupported prefixes.
+fn build_verification_metadata(authorization_endpoint: url::Url) -> WalletMetadata {
+    let mut vp_formats = ClaimFormatMap::new();
+    vp_formats.insert(
+        ClaimFormatDesignation::Other("dc+sd-jwt".to_string()),
+        ClaimFormatPayload::Other(serde_json::json!({})),
+    );
+
+    let mut metadata = WalletMetadata::new(
+        AuthorizationEndpoint(authorization_endpoint),
+        VpFormatsSupported(vp_formats),
+        None,
+    );
+    metadata.insert(ClientIdPrefixesSupported(vec![
+        ClientIdScheme(ClientIdScheme::X509_HASH.to_string()),
+        ClientIdScheme(ClientIdScheme::REDIRECT_URI.to_string()),
+    ]));
+    metadata.insert(RequestObjectSigningAlgValuesSupported(vec![
+        "ES256".to_string()
+    ]));
+    metadata.insert(AuthorizationEncryptionAlgValuesSupported(vec![
+        "ECDH-ES".to_string()
+    ]));
+    metadata.insert(AuthorizationEncryptionEncValuesSupported(vec![
+        "A256GCM".to_string(),
+        "A128GCM".to_string(),
+    ]));
+    metadata
+}
+
+/// Reject `transaction_data` entries whose `type` the wallet does not support.
+///
+/// Per OID4VP §5.1/§8.4 the wallet MUST error if a `transaction_data` entry has
+/// an unrecognized type. This headless wallet supports no transaction_data
+/// types, so any entry is rejected. Entries are base64url-encoded JSON objects.
+fn validate_transaction_data(request_object: &AuthorizationRequestObject) -> Result<(), String> {
+    let Some(td) = request_object.get::<TransactionData>() else {
+        return Ok(());
+    };
+    let td = td.map_err(|e| format!("invalid transaction_data: {e}"))?;
+
+    for entry in &td.0 {
+        // Best-effort decode to name the offending type in the error.
+        let typ = URL_SAFE_NO_PAD
+            .decode(entry)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+            .and_then(|json| json.get("type").and_then(|t| t.as_str()).map(String::from))
+            .unwrap_or_else(|| "<unparseable>".to_string());
+        return Err(format!("unsupported transaction_data type: '{typ}'"));
+    }
+    Ok(())
 }
 
 /// Create an error response

--- a/src/core/authorization_request/verification/mod.rs
+++ b/src/core/authorization_request/verification/mod.rs
@@ -199,16 +199,11 @@ pub(crate) async fn validate_request_against_metadata<W: Wallet + ?Sized>(
             .ok_or_else(|| anyhow::anyhow!("'jwks' is required for encrypted responses"))?
             .map_err(|e| anyhow::anyhow!("failed to parse 'jwks': {e}"))?;
 
-        // Find encryption keys (use="enc") and extract their alg values
+        // Collect the `alg` values of the candidate encryption keys per OID4VP v1.0 Section 8.3.
         let encryption_algs: Vec<String> = jwks
             .keys
             .iter()
-            .filter(|k| {
-                k.get("use")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s == "enc")
-                    .unwrap_or(false)
-            })
+            .filter(|k| !matches!(k.get("use").and_then(|v| v.as_str()), Some(u) if u != "enc"))
             .filter_map(|k| k.get("alg").and_then(|v| v.as_str()).map(String::from))
             .collect();
 

--- a/src/core/authorization_request/verification/mod.rs
+++ b/src/core/authorization_request/verification/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     core::{
+        jwe::find_encryption_jwk,
         metadata::parameters::{
             verifier::{EncryptedResponseEncValuesSupported, JWKs},
             wallet::{
@@ -200,29 +201,19 @@ pub(crate) async fn validate_request_against_metadata<W: Wallet + ?Sized>(
             .map_err(|e| anyhow::anyhow!("failed to parse 'jwks': {e}"))?;
 
         // Collect the `alg` values of the candidate encryption keys per OID4VP v1.0 Section 8.3.
-        let encryption_algs: Vec<String> = jwks
-            .keys
-            .iter()
-            .filter(|k| !matches!(k.get("use").and_then(|v| v.as_str()), Some(u) if u != "enc"))
-            .filter_map(|k| k.get("alg").and_then(|v| v.as_str()).map(String::from))
-            .collect();
+        let jwk_info = find_encryption_jwk(jwks.keys.iter()).map_err(|e| {
+            anyhow::anyhow!("no usable encryption key in jwks per OID4VP v1.0 Section 8.3: {e}")
+        })?;
 
-        if encryption_algs.is_empty() {
-            bail!(
-                "no encryption key with 'alg' found in jwks (required per OID4VP v1.0 Section 8.3)"
-            )
-        }
-
-        // Validate alg against wallet supported values
+        // Validate the selected key's alg against wallet supported values
         if let Some(supported_algs) =
             wallet_metadata.get::<AuthorizationEncryptionAlgValuesSupported>()
         {
             let supported = supported_algs?;
-            let has_supported_alg = encryption_algs.iter().any(|alg| supported.0.contains(alg));
-            if !has_supported_alg {
+            if !supported.0.contains(&jwk_info.alg) {
                 bail!(
-                    "none of the encryption algorithms in jwks ({:?}) are supported by the wallet ({:?})",
-                    encryption_algs,
+                    "encryption algorithm '{}' in jwks is not supported by the wallet ({:?})",
+                    jwk_info.alg,
                     supported.0
                 )
             }

--- a/src/verifier/request_builder.rs
+++ b/src/verifier/request_builder.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use crate::{
     core::{
         authorization_request::{
-            parameters::{ResponseMode, ResponseType, ResponseUri},
+            parameters::{Audience, ResponseMode, ResponseType, ResponseUri},
             AuthorizationRequest, AuthorizationRequestObject, RequestIndirection,
         },
         dcql_query::DcqlQuery,
@@ -113,6 +113,15 @@ impl<'a> RequestBuilder<'a> {
                 "the wallet does not support Client Identifier Prefix '{}'",
                 client_id_prefix.0
             )
+        }
+
+        // Per OID4VP 1.0 Section 5.8, a Request Object MUST carry an `aud` claim.
+        // Default to the SIOPv2 symbolic value used with static Wallet metadata;
+        // callers performing Dynamic Discovery can override it (`aud` = `iss`)
+        // via `with_request_parameter`.
+        if self.request_parameters.get::<Audience>().is_none() {
+            self.request_parameters
+                .insert(Audience("https://self-issued.me/v2".to_string()));
         }
 
         let authorization_request_object: AuthorizationRequestObject =


### PR DESCRIPTION
This updates the code as follows:

- Verifier and wallet conformance adapters gain full HAIP support: `x509_hash` client ID, CA-signed (non-self-signed) leaf with `x5c`, signed request verification, encrypted `direct_post.jwt` responses, real SD-JWT VC issuance, claim/data-minimization handling, and the negative tests (invalid signature, unknown prefix, unknown transaction_data type).

- Two spec-compliance fixes in the library, surfaced and fixed while running the OpenID conformance suite:
  - §8.3: request validation no longer requires `use: enc` on the verifier's encryption JWK. The spec only mandates `alg`; `use` is an optional selection hint. Now aligned with `find_encryption_jwk`.
  - §5.8: the request builder now defaults the request object `aud` to `https://self-issued.me/v2` (static discovery), overridable for dynamic discovery.

